### PR TITLE
Added function to copy template folders to service folder

### DIFF
--- a/bu_isciii/__main__.py
+++ b/bu_isciii/__main__.py
@@ -184,6 +184,7 @@ def new_service(resolution, folder, service_label, service_id, path, no_create_f
         resolution, folder, service_label, service_id, path, no_create_folder
     )
     new_ser.create_folder()
+    new_ser.copy_template()
 
 
 if __name__ == "__main__":

--- a/bu_isciii/new_service.py
+++ b/bu_isciii/new_service.py
@@ -102,7 +102,7 @@ class NewService:
         )
         # service = bu_isciii.json_reader.Service(self.service_id)
         # service_template = new_ser.get_template()
-        service_template = ["viralrecon"]  ###TMP!!
+        service_template = ["viralrecon"]  # TMP!!
         if len(service_template) == 1:
             shutil.copytree(
                 "templates/" + str(service_template[0]),

--- a/bu_isciii/new_service.py
+++ b/bu_isciii/new_service.py
@@ -95,12 +95,19 @@ class NewService:
         return True
 
     def copy_template(self):
-        print("I will copy the template service folders for " + self.service_folder + "!")
-        #service = bu_isciii.json_reader.Service(self.service_id)
-        #service_template = new_ser.get_template()
-        service_template = ["viralrecon"] ###TMP!!
+        print(
+            "I will copy the template service folders for " + self.service_folder + "!"
+        )
+        # service = bu_isciii.json_reader.Service(self.service_id)
+        # service_template = new_ser.get_template()
+        service_template = ["viralrecon"]  ###TMP!!
         if len(service_template) == 1:
-            shutil.copytree("templates/"+str(service_template[0]), str(self.path) + str(self.service_folder + "/"), dirs_exist_ok=True, ignore=shutil.ignore_patterns('README'))
+            shutil.copytree(
+                "templates/" + str(service_template[0]),
+                str(self.path) + str(self.service_folder + "/"),
+                dirs_exist_ok=True,
+                ignore=shutil.ignore_patterns("README"),
+            )
         return True
 
     def get_resolution_id(self):

--- a/bu_isciii/new_service.py
+++ b/bu_isciii/new_service.py
@@ -67,38 +67,38 @@ class NewService:
         )
         self.service_folder = self.resolution_info["resolutionFullNumber"]
         self.services_requested = self.resolution_info["availableServices"]
+        self.full_path = os.path.join(path, self.path, self.service_folder)
 
     def create_folder(self):
         print("I will create the service folder for " + self.resolution_id + "!")
-        isExist = os.path.exists(str(self.path) + str(self.service_folder))
+        isExist = os.path.exists(self.full_path)
         if isExist:
             stderr.print(
                 "[red]ERROR: Directory "
-                + str(self.path)
-                + str(self.service_folder)
+                + self.full_path
                 + " exists",
                 highlight=False,
             )
         else:
             try:
-                os.mkdir(str(self.path) + str(self.service_folder))
+                os.mkdir(self.full_path)
             except OSError:
                 stderr.print(
                     "[red]ERROR: Creation of the directory %s failed"
-                    % (str(self.path) + str(self.service_folder)),
+                    % self.full_path,
                     highlight=False,
                 )
             else:
                 stderr.print(
                     "[green]Successfully created the directory %s"
-                    % (str(self.path) + str(self.service_folder)),
+                    % self.full_path,
                     highlight=False,
                 )
         return True
 
     def copy_template(self):
         print(
-            "I will copy the template service folders for " + self.service_folder + "!"
+            "I will copy the template service folders for " + self.full_path + "!"
         )
         # service = bu_isciii.json_reader.Service(self.service_id)
         # service_template = new_ser.get_template()
@@ -106,7 +106,7 @@ class NewService:
         if len(service_template) == 1:
             shutil.copytree(
                 "templates/" + str(service_template[0]),
-                str(self.path) + str(self.service_folder + "/"),
+                self.full_path,
                 dirs_exist_ok=True,
                 ignore=shutil.ignore_patterns("README"),
             )

--- a/bu_isciii/new_service.py
+++ b/bu_isciii/new_service.py
@@ -67,29 +67,30 @@ class NewService:
 
     def create_folder(self):
         print("I will create the service folder for " + self.resolution_id + "!")
-        os.chdir(self.path)
         isExist = os.path.exists(str(self.path) + str(self.service_folder))
-        if isExist is False:
-            try:
-                os.mkdir(str(self.path) + str(self.service_folder))
-                os.chdir(str(self.path) + str(self.service_folder))
-            except OSError:
-                print(
-                    "ERROR: Creation of the directory %s failed"
-                    % (str(self.path) + str(self.service_folder))
-                )
-            else:
-                print(
-                    "Successfully created the directory %s "
-                    % (str(self.path) + str(self.service_folder))
-                )
-        else:
-            print(
-                "ERROR: Directory "
+        if isExist:
+            stderr.print(
+                "[red]ERROR: Directory "
                 + str(self.path)
                 + str(self.service_folder)
-                + " exists"
+                + " exists",
+                highlight=False,
             )
+        else:
+            try:
+                os.mkdir(str(self.path) + str(self.service_folder))
+            except OSError:
+                stderr.print(
+                    "[red]ERROR: Creation of the directory %s failed"
+                    % (str(self.path) + str(self.service_folder)),
+                    highlight=False,
+                )
+            else:
+                stderr.print(
+                    "[green]Successfully created the directory %s"
+                    % (str(self.path) + str(self.service_folder)),
+                    highlight=False,
+                )
         return True
 
     def copy_template(self):

--- a/bu_isciii/new_service.py
+++ b/bu_isciii/new_service.py
@@ -74,9 +74,7 @@ class NewService:
         isExist = os.path.exists(self.full_path)
         if isExist:
             stderr.print(
-                "[red]ERROR: Directory "
-                + self.full_path
-                + " exists",
+                "[red]ERROR: Directory " + self.full_path + " exists",
                 highlight=False,
             )
         else:
@@ -84,22 +82,18 @@ class NewService:
                 os.mkdir(self.full_path)
             except OSError:
                 stderr.print(
-                    "[red]ERROR: Creation of the directory %s failed"
-                    % self.full_path,
+                    "[red]ERROR: Creation of the directory %s failed" % self.full_path,
                     highlight=False,
                 )
             else:
                 stderr.print(
-                    "[green]Successfully created the directory %s"
-                    % self.full_path,
+                    "[green]Successfully created the directory %s" % self.full_path,
                     highlight=False,
                 )
         return True
 
     def copy_template(self):
-        print(
-            "I will copy the template service folders for " + self.full_path + "!"
-        )
+        print("I will copy the template service folders for " + self.full_path + "!")
         # service = bu_isciii.json_reader.Service(self.service_id)
         # service_template = new_ser.get_template()
         service_template = ["viralrecon"]  # TMP!!

--- a/bu_isciii/new_service.py
+++ b/bu_isciii/new_service.py
@@ -30,6 +30,7 @@ END_OF_HEADER
 import os
 import logging
 
+import shutil
 import rich
 
 # Local imports
@@ -94,6 +95,12 @@ class NewService:
         return True
 
     def copy_template(self):
+        print("I will copy the template service folders for " + self.service_folder + "!")
+        #service = bu_isciii.json_reader.Service(self.service_id)
+        #service_template = new_ser.get_template()
+        service_template = ["viralrecon"] ###TMP!!
+        if len(service_template) == 1:
+            shutil.copytree("templates/"+str(service_template[0]), str(self.path) + str(self.service_folder + "/"), dirs_exist_ok=True, ignore=shutil.ignore_patterns('README'))
         return True
 
     def get_resolution_id(self):

--- a/templates/services.json
+++ b/templates/services.json
@@ -11,7 +11,7 @@
           "folders":["03-assembly/trimming/trimmed", "01-preprocessing", "work"],
           "files":[""]
         },
-        "no_copy": ["RAW", "TMP"]
+        "no_copy": ["RAW", "TMP", "latest"]
     },
     "mtbseq": {
         "label": "",


### PR DESCRIPTION
Created copy_template function so template folder can be copied to destination service folder. Temporarilly added hardcoded in the code the `service_template = ["viralrecon"]  ###TMP!!`

Also, magaed the possibility to call the json module:
```
        # service = bu_isciii.json_reader.Service(self.service_id)
        # service_template = new_ser.get_template()
```