### PR TITLE
Sftp autoclean module

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ BU-ISCIII provides a serie or services in its portfolio for supporting bioinform
     * [copy_sfp](#copy_sftp)
     * [archive](#archive)
     * [bioinfo_doc](#bioinfo_doc)
+    * [autoclean_sftp](#autoclean_sftp)
 * [Aknowledgements](#aknowledgements)
 
 ## Installation
@@ -50,6 +51,8 @@ pip install --force-reinstall --upgrade git+https://github.com/bu-isciii/buiscii
 #### archive
 
 #### bioinfo_doc
+
+#### autoclean_sftp
 
 
 ## Acknowledgements

--- a/bu_isciii/__main__.py
+++ b/bu_isciii/__main__.py
@@ -397,7 +397,7 @@ def archive(resolution, type, year, option):
     default=14,
     help="Integer, remove files older than a window of `-w [int]` days. Default 14 days.",
 )
-def autoclean_sftp():
+def autoclean_sftp(sftp_folder, window):
     """Clean old sftp services"""
     sftp_clean = bu_isciii.autoclean_sftp.AutoremoveSftpService(sftp_folder, window)
     sftp_clean.handle_autoclean_sftp()

--- a/bu_isciii/__main__.py
+++ b/bu_isciii/__main__.py
@@ -381,6 +381,7 @@ def archive(resolution, type, year, option):
     archive_ser = bu_isciii.archive.Archive(resolution, year, type, option)
     archive_ser.handle_archive()
 
+
 # CLEAN OLD SFTP SERVICES
 @bu_isciii_cli.command(help_priority=8)
 @click.option(
@@ -401,6 +402,7 @@ def autoclean_sftp(sftp_folder, days):
     """Clean old sftp services"""
     sftp_clean = bu_isciii.autoclean_sftp.AutoremoveSftpService(sftp_folder, days)
     sftp_clean.handle_autoclean_sftp()
+
 
 if __name__ == "__main__":
     run_bu_isciii()

--- a/bu_isciii/__main__.py
+++ b/bu_isciii/__main__.py
@@ -18,6 +18,7 @@ import bu_isciii.bioinfo_doc
 import bu_isciii.clean
 import bu_isciii.archive
 import bu_isciii.copy_sftp
+import bu_isciii.autoclean_sftp
 
 log = logging.getLogger()
 
@@ -380,6 +381,26 @@ def archive(resolution, type, year, option):
     archive_ser = bu_isciii.archive.Archive(resolution, year, type, option)
     archive_ser.handle_archive()
 
+# CLEAN OLD SFTP SERVICES
+@bu_isciii_cli.command(help_priority=8)
+@click.option(
+    "-s",
+    "--sftp_folder",
+    type=click.Path(),
+    default=None,
+    help="Absolute path to sftp folder",
+)
+@click.option(
+    "-w",
+    "--window",
+    type=int,
+    default=14,
+    help="Integer, remove files older than a window of `-w [int]` days. Default 14 days.",
+)
+def autoclean_sftp():
+    """Clean old sftp services"""
+    sftp_clean = bu_isciii.autoclean_sftp.AutoremoveSftpService(sftp_folder, window)
+    sftp_clean.handle_autoclean_sftp()
 
 if __name__ == "__main__":
     run_bu_isciii()

--- a/bu_isciii/__main__.py
+++ b/bu_isciii/__main__.py
@@ -391,15 +391,15 @@ def archive(resolution, type, year, option):
     help="Absolute path to sftp folder",
 )
 @click.option(
-    "-w",
-    "--window",
+    "-d",
+    "--days",
     type=int,
     default=14,
-    help="Integer, remove files older than a window of `-w [int]` days. Default 14 days.",
+    help="Integer, remove files older than a window of `-d [int]` days. Default 14 days.",
 )
-def autoclean_sftp(sftp_folder, window):
+def autoclean_sftp(sftp_folder, days):
     """Clean old sftp services"""
-    sftp_clean = bu_isciii.autoclean_sftp.AutoremoveSftpService(sftp_folder, window)
+    sftp_clean = bu_isciii.autoclean_sftp.AutoremoveSftpService(sftp_folder, days)
     sftp_clean.handle_autoclean_sftp()
 
 if __name__ == "__main__":

--- a/bu_isciii/autoclean_sftp.py
+++ b/bu_isciii/autoclean_sftp.py
@@ -65,6 +65,7 @@ class AutoremoveSftpService:
         if path is None:
             use_default = bu_isciii.utils.prompt_yn_question("Use default path?: ")
             if use_default:
+                # TODO: repalce 'archive' with 'global' once iskylims_iscides branch has bene merged
                 data_path = bu_isciii.config_json.ConfigJson().get_configuration("archive")["data_path"]
                 self.path = os.path.join(data_path, "sftp")
             else:                             
@@ -93,7 +94,7 @@ class AutoremoveSftpService:
         service_pattern = r'^[SRV][A-Z]+[0-9]+_\d{8}_[A-Z0-9]+_[a-zA-Z]+(?:\.[a-zA-Z]+)?_[a-zA-Z]$'
         
         stderr.print(
-                "[blue]Scanning  " + self.path + "..."
+                "[blue]Scanning " + self.path + "..."
             )
         for root, dirs, files in os.walk(self.path):
             for dir_name in dirs:

--- a/bu_isciii/autoclean_sftp.py
+++ b/bu_isciii/autoclean_sftp.py
@@ -157,7 +157,7 @@ class AutoremoveSftpService:
                         stderr.print("Deleting service: " + service)
                         shutil.rmtree(service)
 
-                    except OSError as o:
+                    except OSError:
                         stderr.print(
                             "[red]ERROR: Cannot delete service folder:" + service
                         )

--- a/bu_isciii/autoclean_sftp.py
+++ b/bu_isciii/autoclean_sftp.py
@@ -136,11 +136,11 @@ class AutoremoveSftpService:
                         stderr.print(
                             "Deleting service:" + service
                         )
-                        #shutil.rmtree(os.path.join(self.path, sftp_folder))
+                        shutil.rmtree(service)
                     
                     except OSError as o:
                         stderr.print(
-                            "[red]ERROR: Cannot delete service folder:" + service + os.path.join(self.path, service)
+                            "[red]ERROR: Cannot delete service folder:" + service
                         )
             else:
                 stderr.print(

--- a/bu_isciii/autoclean_sftp.py
+++ b/bu_isciii/autoclean_sftp.py
@@ -1,13 +1,4 @@
 #!/usr/bin/env python
-#   sftp_autoclean.py
-#
-#   Gaol: automatically remove service from sftp after X days after the last update/access  
-#       Sub goals:
-#           1. add && custom stderr.prints + colors
-#           2. Get sftp service metadata from jsons
-#           3. Mark services that are stored for long period-time
-#           4. Provide a log-completition file. 
-#           5. linting -- pep8 & black
 
 # import
 import os
@@ -75,8 +66,7 @@ class AutoremoveSftpService:
             if use_default:
                 # TODO: add import json-api sftp  path
                 #self.path = bu_isciii.config_json.ConfigJson().get_configuration("PATHTO")
-                print("yes")
-                sys.exit()
+                sys.exit('Still developing this...remove sys.exit once jsonApi is connected. Exiting')
             else:                             
                 self.path = bu_isciii.utils.prompt_path(msg="Directory where the sftp site is allocated:")
         else:
@@ -89,8 +79,8 @@ class AutoremoveSftpService:
     def check_path_exists(self):
         # if the folder path is not found, then bye
         if not os.path.exists(self.path):
-            print( # TODO: replace with stderr.print
-                "[red] ERROR: It seems like finding the correct path is beneath me. I apologise. The path: %s does not exitst. Exiting.."
+            stderr.print(
+                "[red]ERROR: It seems like finding the correct path is beneath me. I apologise. The path:" + self.path + "does not exitst. Exiting.."
                 % self.path
             )
             sys.exit()
@@ -102,6 +92,9 @@ class AutoremoveSftpService:
         self.sftp_services = {} # {sftp-service_path : last_update}
         service_pattern = r'^[SRV][A-Z]+[0-9]+_\d{8}_[A-Z0-9]+_[a-zA-Z]+(?:\.[a-zA-Z]+)?_[a-zA-Z]$'
         
+        stderr.print(
+                "[blue]Scanning  " + self.path + "..."
+            )
         for root, dirs, files in os.walk(self.path):
             for dir_name in dirs:
                 match = re.match(service_pattern, dir_name)
@@ -126,19 +119,33 @@ class AutoremoveSftpService:
     # Delete marked services 
     def remove_oldservice(self):
         if len(self.marked_services) == 0:
-            sys.exit(f"sftp-site up to date. There are no services  older than {self.window} days. Skiping autoclean_sftp...")
+            stderr.print(
+                "[yellow]sftp-site up to date. There are no services  older than " + str(self.window.days) + " days. Skiping autoclean-sftp... "
+            )
+            sys.exit()
         else:
             service_elements='\n'.join(self.marked_services)
-            print(f"The following services are going to be deleted from the sftp:\n{service_elements}") # replace with isciii std err
+            stderr.print(
+                "The following services are going to be deleted from the sftp:\n" + service_elements
+            )
             confirm_sftp_delete = bu_isciii.utils.prompt_yn_question("Are you sure?: ")
             if confirm_sftp_delete:
                 for service in self.marked_services:
                     try:
-                        print(f"Deleting service: {service}") # replace with isciii std err
+                        stderr.print(
+                            "Deleting service:" + service
+                        )
                         #shutil.rmtree(os.path.join(self.path, sftp_folder))
                     
                     except OSError as o:
-                        print(f"[ERROR] Cannot delete service folder {service}: {os.path.join(self.path, service)}") # replace with isciii std err & import colors
+                        stderr.print(
+                            "[red]ERROR: Cannot delete service folder:" + service + os.path.join(self.path, service)
+                        )
+            else:
+                stderr.print(
+                    'Aborting ...'
+                )
+                sys.exit()
     
     def handle_autoclean_sftp(self):
         self.check_path_exists()

--- a/bu_isciii/autoclean_sftp.py
+++ b/bu_isciii/autoclean_sftp.py
@@ -11,6 +11,7 @@
 
 # import
 import os
+import re
 import shutil
 import sys
 import logging
@@ -85,11 +86,18 @@ class AutoremoveSftpService:
     
     def list_sftp_services(self): # TODO: dict_sftp_ **
         self.sftp_services = {}
-        for service_dir in os.listdir(self.path):
-            service_fullPath = os.path.join(self.path, service_dir)
-            service_finder   = LastMofdificationFinder(service_fullPath)
-            service_last_modification = service_finder.find_last_modification()
-            self.sftp_services[service_dir] = service_last_modification
+
+        service_pattern = r'^[SRV][A-Z]+[0-9]+_\d{8}_[A-Z0-9]+_[a-zA-Z]+(?:\.[a-zA-Z]+)?_[a-zA-Z]$'
+        for root, dirs, files in os.walk(self.path):
+            for dir_name in dirs:
+                match = re.match(service_pattern, dir_name)
+                if match:
+                    sftp_service_fullPath = os.path.join(root,dir_name)
+                    
+                    # Get service last modification
+                    service_finder = LastMofdificationFinder(sftp_service_fullPath)
+                    service_last_modification = service_finder.find_last_modification()
+                    self.sftp_services[sftp_service_fullPath]= service_last_modification
     
     def mark_toDelete(self, window=2): # TODO: 14 days
         self.window = timedelta(days=window)
@@ -118,5 +126,5 @@ class AutoremoveSftpService:
 sftp_site_autoclean = AutoremoveSftpService(None)
 sftp_site_autoclean.check_path_exists()
 sftp_site_autoclean.list_sftp_services()
-sftp_site_autoclean.mark_toDelete()
-sftp_site_autoclean.remove_oldservice()
+#sftp_site_autoclean.mark_toDelete()
+#sftp_site_autoclean.remove_oldservice()

--- a/bu_isciii/autoclean_sftp.py
+++ b/bu_isciii/autoclean_sftp.py
@@ -14,6 +14,7 @@ from datetime import datetime, timedelta
 # local import
 import bu_isciii 
 import bu_isciii.utils
+import bu_isciii.config_json
 
 log = logging.getLogger(__name__)
 stderr = rich.console.Console(
@@ -64,9 +65,8 @@ class AutoremoveSftpService:
         if path is None:
             use_default = bu_isciii.utils.prompt_yn_question("Use default path?: ")
             if use_default:
-                # TODO: add import json-api sftp  path
-                #self.path = bu_isciii.config_json.ConfigJson().get_configuration("PATHTO")
-                sys.exit('Still developing this...remove sys.exit once jsonApi is connected. Exiting')
+                data_path = bu_isciii.config_json.ConfigJson().get_configuration("archive")["data_path"]
+                self.path = os.path.join(data_path, "sftp")
             else:                             
                 self.path = bu_isciii.utils.prompt_path(msg="Directory where the sftp site is allocated:")
         else:

--- a/bu_isciii/autoclean_sftp.py
+++ b/bu_isciii/autoclean_sftp.py
@@ -73,12 +73,18 @@ class AutoremoveSftpService:
     and remove those that have not been updated/modified
     within 14 days
     '''
-    def __init__(self, path):
+    def __init__(self, path=None):
         if path is None:
-            # TODO: Replace with stderr() once implemented
-            print("Directory where the sftp site is allocated")
-            # TODO: Replace with bu_isciii.utils.prompt_path() once implemented
-            self.path = prompt_path(msg="Path")
+            use_default = prompt_yn_question("Use default path?: ")
+            if use_default:
+                #self.path = bu_isciii.config_json.ConfigJson().get_configuration("PATHTO")
+                print("yes")
+                sys.exit()
+            else:             
+                # TODO: Replace with stderr() once implemented
+                
+                # TODO: Replace with bu_isciii.utils.prompt_path() once implemented
+                self.path = prompt_path(msg="Directory where the sftp site is allocated:")
         else:
             self.path = path
 
@@ -144,3 +150,5 @@ class AutoremoveSftpService:
         self.mark_toDelete()
         self.remove_oldservice()
     
+clean_path = AutoremoveSftpService()
+clean_path.handle_autoclean_sftp()

--- a/bu_isciii/autoclean_sftp.py
+++ b/bu_isciii/autoclean_sftp.py
@@ -123,6 +123,7 @@ for service_dir in os.listdir(sftp_path):
         dirs_toDelete.append(service_dir)
     else:
         continue
+
 print(dirs_toDelete)
 #removeObj = AutoremoveSftpService(sftp_path, ["service_test1", "service_test2"]) 
 #removeObj.remove_service()

--- a/bu_isciii/autoclean_sftp.py
+++ b/bu_isciii/autoclean_sftp.py
@@ -85,21 +85,21 @@ class AutoremoveSftpService:
             sys.exit()
     
     def get_sftp_services(self):
-        self.sftp_services = {}
-
+        self.sftp_services = {} # {sftp-service_path : last_update}
         service_pattern = r'^[SRV][A-Z]+[0-9]+_\d{8}_[A-Z0-9]+_[a-zA-Z]+(?:\.[a-zA-Z]+)?_[a-zA-Z]$'
+        
         for root, dirs, files in os.walk(self.path):
             for dir_name in dirs:
                 match = re.match(service_pattern, dir_name)
                 if match:
                     sftp_service_fullPath = os.path.join(root,dir_name)
                     
-                    # Get service last modification
+                    # Get sftp-service last modification
                     service_finder = LastMofdificationFinder(sftp_service_fullPath)
                     service_last_modification = service_finder.find_last_modification()
-                    self.sftp_services[sftp_service_fullPath]= service_last_modification
-    
-    def mark_toDelete(self, window=2): # TODO: 14 days
+                    self.sftp_services[sftp_service_fullPath] = service_last_modification
+        
+    def mark_toDelete(self, window=14): # TODO: 14 days
         self.window = timedelta(days=window)
         self.marked_services = []
 
@@ -112,7 +112,7 @@ class AutoremoveSftpService:
             sys.exit(f"The sftp site has not service folders older than {self.window} days. Skiping autoclean_sftp...")
         else:
             service_elements='\n'.join(self.marked_services)
-            print(f"The following services will be deleted:\n{service_elements}") # replace with isciii std err
+            print(f"The following services are going to be deleted from the sftp:\n{service_elements}") # replace with isciii std err
             confirm_sftp_delete = prompt_yn_question("Are you sure? (Y/n): ")
             if confirm_sftp_delete:
                 for service in self.marked_services:
@@ -125,6 +125,6 @@ class AutoremoveSftpService:
     
 sftp_site_autoclean = AutoremoveSftpService(None)
 sftp_site_autoclean.check_path_exists()
-sftp_site_autoclean.list_sftp_services()
-#sftp_site_autoclean.mark_toDelete()
-#sftp_site_autoclean.remove_oldservice()
+sftp_site_autoclean.get_sftp_services()
+sftp_site_autoclean.mark_toDelete()
+sftp_site_autoclean.remove_oldservice()

--- a/bu_isciii/autoclean_sftp.py
+++ b/bu_isciii/autoclean_sftp.py
@@ -84,7 +84,7 @@ class AutoremoveSftpService:
             )
             sys.exit()
     
-    def list_sftp_services(self): # TODO: dict_sftp_ **
+    def get_sftp_services(self):
         self.sftp_services = {}
 
         service_pattern = r'^[SRV][A-Z]+[0-9]+_\d{8}_[A-Z0-9]+_[a-zA-Z]+(?:\.[a-zA-Z]+)?_[a-zA-Z]$'

--- a/bu_isciii/autoclean_sftp.py
+++ b/bu_isciii/autoclean_sftp.py
@@ -112,24 +112,24 @@ class AutoremoveSftpService:
                 self.marked_services.append(key) 
 
     # TODO: UPDATE THIS
-    def remove_service(self): # prompt thing
-    
-        service_elements='\n'.join(self.services)
-        print(f"The following services will be deleted:\n{service_elements}") # replace with isciii std err
-        confirm_sftp_delete = prompt_yn_question(
-            "Are you sure?:"
-            )
-        if confirm_sftp_delete:
-            for sftp_folder in self.services:
-                try:
-                    print(f"Deleting service {sftp_folder}: {os.path.join(self.path, sftp_folder)}") # replace with isciii std err
-                    #shutil.rmtree(os.path.join(self.path, sftp_folder))
+    def remove_oldservice(self): # prompt thing
+        if len(self.marked_services) == 0:
+            sys.exit(f"The sftp site has not service folders older than {self.window} days")
+        else:
+            service_elements='\n'.join(self.marked_services)
+            print(f"The following services will be deleted:\n{service_elements}") # replace with isciii std err
+            confirm_sftp_delete = prompt_yn_question("Are you sure?:")
+            if confirm_sftp_delete:
+                for service in self.marked_services:
+                    try:
+                        print(f"Deleting service {service}: {os.path.join(self.path, service)}") # replace with isciii std err
+                        #shutil.rmtree(os.path.join(self.path, sftp_folder))
                     
-                except OSError as o:
-                    print(f"[ERROR] Cannot delete service folder {sftp_folder}: {os.path.join(self.path, sftp_folder)}") # replace with isciii std err
+                    except OSError as o:
+                        print(f"[ERROR] Cannot delete service folder {service}: {os.path.join(self.path, service)}") # replace with isciii std err
     
 sftp_site_autoclean = AutoremoveSftpService(None)
 sftp_site_autoclean.check_path_exists()
 sftp_site_autoclean.list_sftp_services()
 sftp_site_autoclean.mark_toDelete()
-print(sftp_site_autoclean.marked_services)
+sftp_site_autoclean.remove_oldservice()

--- a/bu_isciii/autoclean_sftp.py
+++ b/bu_isciii/autoclean_sftp.py
@@ -3,7 +3,6 @@
 #
 #   Gaol: automatically remove service from sftp after X days after the last update/access  
 #       Sub goals:
-#           0. Connect to package adding handle in __main__.py
 #           1. add && custom stderr.prints + colors
 #           2. Get sftp service metadata from jsons
 #           3. Mark services that are stored for long period-time
@@ -19,7 +18,6 @@ import logging
 import shutil
 import rich
 
-import questionary
 from datetime import datetime, timedelta
 
 # local import
@@ -34,27 +32,10 @@ stderr = rich.console.Console(
     force_terminal=bu_isciii.utils.rich_force_colors(),
 )
 
-# =================================================================
-# Backbone and utils
-# =================================================================
-
-# temp cp from utils
-def prompt_path(msg):
-    source = questionary.path(msg).unsafe_ask()
-    return source
-
-def prompt_yn_question(msg):
-    confirmation = questionary.confirm(msg).unsafe_ask()
-    return confirmation
-
-# New functions(mv to utils)
-def timestamp_converter(timestamp): # import datetime
+# TODO: add to utils.py?
+def timestamp_converter(timestamp):
     date_formated = datetime.fromtimestamp(timestamp)
     return date_formated
-
-def last_updated_file(datetime_list):
-    latest_date = max(datetime_list)
-    return latest_date
 
 class LastMofdificationFinder:
     '''
@@ -90,16 +71,14 @@ class AutoremoveSftpService:
     def __init__(self, path=None, window=14):
         # Parse input path
         if path is None:
-            use_default = prompt_yn_question("Use default path?: ")
+            use_default = bu_isciii.utils.prompt_yn_question("Use default path?: ")
             if use_default:
+                # TODO: add import json-api sftp  path
                 #self.path = bu_isciii.config_json.ConfigJson().get_configuration("PATHTO")
                 print("yes")
                 sys.exit()
-            else:             
-                # TODO: Replace with stderr() once implemented
-                
-                # TODO: Replace with bu_isciii.utils.prompt_path() once implemented
-                self.path = prompt_path(msg="Directory where the sftp site is allocated:")
+            else:                             
+                self.path = bu_isciii.utils.prompt_path(msg="Directory where the sftp site is allocated:")
         else:
             self.path = path
         
@@ -151,7 +130,7 @@ class AutoremoveSftpService:
         else:
             service_elements='\n'.join(self.marked_services)
             print(f"The following services are going to be deleted from the sftp:\n{service_elements}") # replace with isciii std err
-            confirm_sftp_delete = prompt_yn_question("Are you sure?: ")
+            confirm_sftp_delete = bu_isciii.utils.prompt_yn_question("Are you sure?: ")
             if confirm_sftp_delete:
                 for service in self.marked_services:
                     try:

--- a/bu_isciii/autoclean_sftp.py
+++ b/bu_isciii/autoclean_sftp.py
@@ -12,7 +12,7 @@ import rich
 from datetime import datetime, timedelta
 
 # local import
-import bu_isciii 
+import bu_isciii
 import bu_isciii.utils
 import bu_isciii.config_json
 
@@ -24,19 +24,22 @@ stderr = rich.console.Console(
     force_terminal=bu_isciii.utils.rich_force_colors(),
 )
 
+
 # TODO: add to utils.py?
 def timestamp_converter(timestamp):
     date_formated = datetime.fromtimestamp(timestamp)
     return date_formated
 
+
 class LastMofdificationFinder:
-    '''
+    """
     Identifies the lates modification in a directory
-    '''
+    """
+
     def __init__(self, path):
         self.path = path
         self.last_modified_time = 0
-    
+
     def find_last_modification(self):
         self.get_last_modified(self.path)
         return timestamp_converter(self.last_modified_time)
@@ -49,34 +52,43 @@ class LastMofdificationFinder:
                 file_path = os.path.join(root, file)
                 file_modified_time = os.path.getmtime(file_path)
                 if file_modified_time > last_modified_time:
-                        last_modified_time = file_modified_time
+                    last_modified_time = file_modified_time
 
         if last_modified_time > self.last_modified_time:
-                    self.last_modified_time = last_modified_time
+            self.last_modified_time = last_modified_time
+
 
 class AutoremoveSftpService:
-    '''
-    Identifies service's stored in an sftp directory 
+    """
+    Identifies service's stored in an sftp directory
     and remove those that have not been updated/modified
     within 14 days
-    '''
+    """
+
     def __init__(self, path=None, days=14):
         # Parse input path
         if path is None:
             use_default = bu_isciii.utils.prompt_yn_question("Use default path?: ")
             if use_default:
                 # TODO: repalce 'archive' with 'global' once iskylims_iscides branch has bene merged
-                data_path = bu_isciii.config_json.ConfigJson().get_configuration("archive")["data_path"]
+                data_path = bu_isciii.config_json.ConfigJson().get_configuration(
+                    "archive"
+                )["data_path"]
                 self.path = os.path.join(data_path, "sftp")
-            else:                             
-                self.path = bu_isciii.utils.prompt_path(msg="Directory where the sftp site is allocated:")
+            else:
+                self.path = bu_isciii.utils.prompt_path(
+                    msg="Directory where the sftp site is allocated:"
+                )
         else:
             self.path = path
-        
+
         # Define the margin threshold of days to mark old services
         self.days = timedelta(days=days)
         stderr.print(
-            "Services older than " + str(self.days.days) + " days are going to be deleted from " + self.path
+            "Services older than "
+            + str(self.days.days)
+            + " days are going to be deleted from "
+            + self.path
         )
 
     # TODO: modify this. PR to make this method reusable outside the class
@@ -84,73 +96,75 @@ class AutoremoveSftpService:
         # if the folder path is not found, then bye
         if not os.path.exists(self.path):
             stderr.print(
-                "[red]ERROR: It seems like finding the correct path is beneath me. I apologise. The path:" + self.path + "does not exitst. Exiting.."
-                % self.path
+                "[red]ERROR: It seems like finding the correct path is beneath me. I apologise. The path:"
+                + self.path
+                + "does not exitst. Exiting.." % self.path
             )
             sys.exit()
-        else: 
+        else:
             return True
-    
+
     # Uses regex to identify sftp-services & gets their lates modification
     def get_sftp_services(self):
-        self.sftp_services = {} # {sftp-service_path : last_update}
-        service_pattern = r'^[SRV][A-Z]+[0-9]+_\d{8}_[A-Z0-9]+_[a-zA-Z]+(?:\.[a-zA-Z]+)?_[a-zA-Z]$'
-        
-        stderr.print(
-                "[blue]Scanning " + self.path + "..."
-            )
+        self.sftp_services = {}  # {sftp-service_path : last_update}
+        service_pattern = (
+            r"^[SRV][A-Z]+[0-9]+_\d{8}_[A-Z0-9]+_[a-zA-Z]+(?:\.[a-zA-Z]+)?_[a-zA-Z]$"
+        )
+
+        stderr.print("[blue]Scanning " + self.path + "...")
         for root, dirs, files in os.walk(self.path):
             for dir_name in dirs:
                 match = re.match(service_pattern, dir_name)
                 if match:
-                    sftp_service_fullPath = os.path.join(root,dir_name)
-                    
+                    sftp_service_fullPath = os.path.join(root, dir_name)
+
                     # Get sftp-service last modification
                     service_finder = LastMofdificationFinder(sftp_service_fullPath)
                     service_last_modification = service_finder.find_last_modification()
-                    self.sftp_services[sftp_service_fullPath] = service_last_modification
+                    self.sftp_services[
+                        sftp_service_fullPath
+                    ] = service_last_modification
         if len(self.sftp_services) == 0:
             sys.exit(f"No services found in {self.path}")
-    
-    # Mark services older than $days    
+
+    # Mark services older than $days
     def mark_toDelete(self):
         self.marked_services = []
 
         for key, value in self.sftp_services.items():
             if datetime.now() - value > self.days:
                 self.marked_services.append(key)
-    
-    # Delete marked services 
+
+    # Delete marked services
     def remove_oldservice(self):
         if len(self.marked_services) == 0:
             stderr.print(
-                "[yellow]sftp-site up to date. There are no services  older than " + str(self.days.days) + " days. Skiping autoclean-sftp... "
+                "[yellow]sftp-site up to date. There are no services  older than "
+                + str(self.days.days)
+                + " days. Skiping autoclean-sftp... "
             )
             sys.exit()
         else:
-            service_elements='\n'.join(self.marked_services)
+            service_elements = "\n".join(self.marked_services)
             stderr.print(
-                "The following services are going to be deleted from the sftp:\n" + service_elements
+                "The following services are going to be deleted from the sftp:\n"
+                + service_elements
             )
             confirm_sftp_delete = bu_isciii.utils.prompt_yn_question("Are you sure?: ")
             if confirm_sftp_delete:
                 for service in self.marked_services:
                     try:
-                        stderr.print(
-                            "Deleting service: " + service
-                        )
+                        stderr.print("Deleting service: " + service)
                         shutil.rmtree(service)
-                    
+
                     except OSError as o:
                         stderr.print(
                             "[red]ERROR: Cannot delete service folder:" + service
                         )
             else:
-                stderr.print(
-                    'Aborting ...'
-                )
+                stderr.print("Aborting ...")
                 sys.exit()
-    
+
     def handle_autoclean_sftp(self):
         self.check_path_exists()
         self.get_sftp_services()

--- a/bu_isciii/sftp_autoclean.py
+++ b/bu_isciii/sftp_autoclean.py
@@ -112,11 +112,17 @@ else:
         "Path to the directory containing the service metadata"
         )
 
-finder = LastMofdificationFinder(sftp_path)
-last_modification_time = finder.find_last_modification()
-
-print(last_modification_time)
-print(f"The last modification time is: {last_modification_time}")
-
-removeObj = AutoremoveSftpService(sftp_path, ["service_test1", "service_test2"]) 
-removeObj.remove_service()
+dirs_toDelete = []
+time_window = timedelta(days=2)
+for service_dir in os.listdir(sftp_path):
+    service_fullPath = os.path.join(sftp_path, service_dir)
+    service_finder   = LastMofdificationFinder(service_fullPath)
+    service_last_modification = service_finder.find_last_modification()
+    delta = datetime.now() - service_last_modification
+    if delta > time_window:
+        dirs_toDelete.append(service_dir)
+    else:
+        continue
+print(dirs_toDelete)
+#removeObj = AutoremoveSftpService(sftp_path, ["service_test1", "service_test2"]) 
+#removeObj.remove_service()

--- a/bu_isciii/sftp_autoclean.py
+++ b/bu_isciii/sftp_autoclean.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+#   sftp_autoclean.py
+#
+#   Gaol: automatically remove service from sftp after X days after the last update/access  
+#       Sub goals:
+#           1. Get user confirmation --> yes/no [prompt]
+#           2. Agument -p [path] or default [resolution.id ftp path]
+#           1. Get sftp service metadata from jsons
+#           2. Get last access/modification date (this may be checked not only in the parent floder but also in all childrens)   
+#           3. Implement logic. I condition is met then, apply auto-cleanup
+#           4. Add a prortection property in order to avoid cleaning files that will be store in sftp for long-period time.
+#           5. Provide a log-completition file. 
+#           6. linting -- pep8 & black
+
+# import
+import os
+import sys
+import logging
+import rich
+import questionary
+from datetime import datetime, timedelta
+
+# import locals
+#import buisciii.utils
+
+# add loggin and colors
+
+# create class
+
+# =================================================================
+# Backbone and utils
+# =================================================================
+
+# temp cp from utils
+def prompt_path(msg):
+    source = questionary.path(msg).unsafe_ask()
+    return source
+
+def prompt_yn_question(msg):
+    confirmation = questionary.confirm(msg).unsafe_ask()
+    return confirmation
+
+
+use_default = prompt_yn_question( # replace with buisciii.utils.prompt_path after testing it
+    "Do you want to use the default sftp path <var>?:" # get config_json keys
+    )
+
+if use_default:
+    sftp_path = "home/da.valle/work/bi/test/service/"
+else:
+    sftp_path = prompt_path( # replace with buisciii.utils.prompt_path after testing it
+    "Path to the directory containing the sftp directory: "
+    )
+    # Validate user's dirif the directory path exists
+    while sftp_path is None or not os.path.isdir(sftp_path):
+        # TODO: this print must be replaced by stderr... to be homogenous to buisciii tools
+        print("Invalid directory path. Please try again.")
+        sftp_path = prompt_path( # replace with buisciii.utils.prompt_path after testing it
+        "Path to the directory containing the service metadata"
+        )

--- a/bu_isciii/sftp_autoclean.py
+++ b/bu_isciii/sftp_autoclean.py
@@ -40,21 +40,54 @@ def prompt_yn_question(msg):
     confirmation = questionary.confirm(msg).unsafe_ask()
     return confirmation
 
+# New functions(mv to utils)
+def timestamp_converter(timestamp): # import datetime
+    date_formated = datetime.fromtimestamp(timestamp)
+    return date_formated
+
+def last_updated_file(datetime_list):
+    latest_date = max(datetime_list)
+    return latest_date
+
+class LastMofdificationFinder():
+    def __init__(self, path):
+        self.path = path
+        self.last_modified_time = 0
+    
+    def find_last_modification(self):
+        self.get_last_modified(self.path)
+        return timestamp_converter(self.last_modified_time)
+
+    def get_last_modified(self, directory):
+        last_modified_time = os.path.getmtime(directory)
+
+        for root, dirs, files in os.walk(self.path):
+            for file in files:
+                file_path = os.path.join(root, file)
+                file_modified_time = os.path.getmtime(file_path)
+                if file_modified_time > last_modified_time:
+                        last_modified_time = file_modified_time
+
+        if last_modified_time > self.last_modified_time:
+                    self.last_modified_time = last_modified_time
 
 use_default = prompt_yn_question( # replace with buisciii.utils.prompt_path after testing it
     "Do you want to use the default sftp path <var>?:" # get config_json keys
     )
 
 if use_default:
-    sftp_path = "home/da.valle/work/bi/test/service/"
+    sftp_path = "/home/da.valle/work/bi/test/service/" # take it fron json
 else:
     sftp_path = prompt_path( # replace with buisciii.utils.prompt_path after testing it
     "Path to the directory containing the sftp directory: "
     )
-    # Validate user's dirif the directory path exists
     while sftp_path is None or not os.path.isdir(sftp_path):
         # TODO: this print must be replaced by stderr... to be homogenous to buisciii tools
         print("Invalid directory path. Please try again.")
         sftp_path = prompt_path( # replace with buisciii.utils.prompt_path after testing it
         "Path to the directory containing the service metadata"
         )
+
+finder = LastMofdificationFinder(sftp_path)
+last_modification_time = finder.find_last_modification()
+print(f"The last modification time is: {last_modification_time}")

--- a/bu_isciii/sftp_autoclean.py
+++ b/bu_isciii/sftp_autoclean.py
@@ -14,6 +14,7 @@
 
 # import
 import os
+import shutil
 import sys
 import logging
 import rich
@@ -49,7 +50,7 @@ def last_updated_file(datetime_list):
     latest_date = max(datetime_list)
     return latest_date
 
-class LastMofdificationFinder():
+class LastMofdificationFinder:
     def __init__(self, path):
         self.path = path
         self.last_modified_time = 0
@@ -71,6 +72,29 @@ class LastMofdificationFinder():
         if last_modified_time > self.last_modified_time:
                     self.last_modified_time = last_modified_time
 
+# TODO: add corner case: service list to be celaned, empty 
+class AutoremoveSftpService:
+    def __init__(self, path, services):
+        self.path     = path
+        self.services = services
+        self.action   = '' # promt to confirm service autoclean. 
+    
+    def remove_service(self): # prompt thing
+        service_elements='\n'.join(self.services)
+        print(f"The following services will be deleted:\n{service_elements}") # replace with isciii std err
+        confirm_sftp_delete = prompt_yn_question(
+            "Are you sure?:"
+            )
+        if confirm_sftp_delete:
+            for sftp_folder in self.services:
+                try:
+                    print(f"Deleting service {sftp_folder}: {os.path.join(self.path, sftp_folder)}") # replace with isciii std err
+                    #shutil.rmtree(os.path.join(self.path, sftp_folder))
+                    
+                except OSError as o:
+                    print(f"[ERROR] Cannot delete service folder {sftp_folder}: {os.path.join(self.path, sftp_folder)}") # replace with isciii std err
+
+
 use_default = prompt_yn_question( # replace with buisciii.utils.prompt_path after testing it
     "Do you want to use the default sftp path <var>?:" # get config_json keys
     )
@@ -90,4 +114,9 @@ else:
 
 finder = LastMofdificationFinder(sftp_path)
 last_modification_time = finder.find_last_modification()
+
+print(last_modification_time)
 print(f"The last modification time is: {last_modification_time}")
+
+removeObj = AutoremoveSftpService(sftp_path, ["service_test1", "service_test2"]) 
+removeObj.remove_service()


### PR DESCRIPTION
New module to remove the old services in the sftp:
- Finds all services listed in the sftp
- For each service determines the last modification/creation date by scanning all files stored in it
- Marks services older than 14 days (default: `-d 14`) as old-services
- Deletes old services from sftp