### PR TITLE
Introduction of credentials as API authentication method

### DIFF
--- a/bu_isciii/__main__.py
+++ b/bu_isciii/__main__.py
@@ -314,11 +314,11 @@ def clean(ctx, resolution, path, ask_path, option):
     show removable files or show folders for no copy.
     """
     clean = bu_isciii.clean.CleanUp(
-        resolution, 
-        path, 
-        ask_path, 
-        option, 
-        ctx.obj["api_user"], 
+        resolution,
+        path,
+        ask_path,
+        option,
+        ctx.obj["api_user"],
         ctx.obj["api_password"]
     )
     clean.handle_clean()

--- a/bu_isciii/__main__.py
+++ b/bu_isciii/__main__.py
@@ -205,7 +205,12 @@ def new_service(ctx, resolution, path, no_create_folder, ask_path):
     Create new service, it will create folder and copy template depending on selected service.
     """
     new_ser = bu_isciii.new_service.NewService(
-        resolution, path, no_create_folder, ask_path, ctx.obj["api_user"], ctx.obj["api_password"]
+        resolution,
+        path,
+        no_create_folder,
+        ask_path,
+        ctx.obj["api_user"],
+        ctx.obj["api_password"],
     )
     new_ser.create_new_service()
 
@@ -251,7 +256,13 @@ def scratch(ctx, resolution, path, tmp_dir, direction, ask_path):
     Copy service folder to scratch directory for execution.
     """
     scratch_copy = bu_isciii.scratch.Scratch(
-        resolution, path, tmp_dir, direction, ask_path, ctx.obj["api_user"], ctx.obj["api_password"]
+        resolution,
+        path,
+        tmp_dir,
+        direction,
+        ask_path,
+        ctx.obj["api_user"],
+        ctx.obj["api_password"],
     )
     scratch_copy.handle_scratch()
 
@@ -302,7 +313,9 @@ def clean(ctx, resolution, path, ask_path, option):
     Service cleaning. It will either remove big files, rename folders before copy, revert this renaming,
     show removable files or show folders for no copy.
     """
-    clean = bu_isciii.clean.CleanUp(resolution, path, ask_path, option, ctx.obj["api_user"], ctx.obj["api_password"])
+    clean = bu_isciii.clean.CleanUp(
+        resolution, path, ask_path, option, ctx.obj["api_user"], ctx.obj["api_password"]
+    )
     clean.handle_clean()
 
 
@@ -336,7 +349,12 @@ def copy_sftp(ctx, resolution, path, ask_path, sftp_folder):
     Copy resolution FOLDER to sftp, change status of resolution in iskylims and generate md, pdf, html.
     """
     new_del = bu_isciii.copy_sftp.CopySftp(
-        resolution, path, ask_path, sftp_folder, ctx.obj["api_user"], ctx.obj["api_password"]
+        resolution,
+        path,
+        ask_path,
+        sftp_folder,
+        ctx.obj["api_user"],
+        ctx.obj["api_password"],
     )
     new_del.copy_sftp()
 
@@ -379,22 +397,43 @@ def finish(ctx, resolution, path, ask_path, sftp_folder, tmp_dir):
     """
     print("Starting cleaning scratch directory: " + tmp_dir)
     clean_scratch = bu_isciii.clean.CleanUp(
-        resolution, tmp_dir, ask_path, "clean", ctx.obj["api_user"], ctx.obj["api_password"]
+        resolution,
+        tmp_dir,
+        ask_path,
+        "clean",
+        ctx.obj["api_user"],
+        ctx.obj["api_password"],
     )
     clean_scratch.handle_clean()
     print("Starting copy from scratch directory: " + tmp_dir + " to service directory.")
     copy_scratch2service = bu_isciii.scratch.Scratch(
-        resolution, path, tmp_dir, "Scratch_to_service", ask_path, ctx.obj["api_user"], ctx.obj["api_password"]
+        resolution,
+        path,
+        tmp_dir,
+        "Scratch_to_service",
+        ask_path,
+        ctx.obj["api_user"],
+        ctx.obj["api_password"],
     )
     copy_scratch2service.handle_scratch()
     print("Starting renaming of the service directory.")
     rename_databi = bu_isciii.clean.CleanUp(
-        resolution, path, ask_path, "rename_nocopy", ctx.obj["api_user"], ctx.obj["api_password"]
+        resolution,
+        path,
+        ask_path,
+        "rename_nocopy",
+        ctx.obj["api_user"],
+        ctx.obj["api_password"],
     )
     rename_databi.handle_clean()
     print("Starting copy of the service directory to the SFTP folder")
     copy_sftp = bu_isciii.copy_sftp.CopySftp(
-        resolution, path, ask_path, sftp_folder, ctx.obj["api_user"], ctx.obj["api_password"]
+        resolution,
+        path,
+        ask_path,
+        sftp_folder,
+        ctx.obj["api_user"],
+        ctx.obj["api_password"],
     )
     copy_sftp.copy_sftp()
     print("Service correctly in SFTP folder")
@@ -454,7 +493,15 @@ def finish(ctx, resolution, path, ask_path, sftp_folder, tmp_dir):
 )
 @click.pass_context
 def bioinfo_doc(
-    ctx, type, resolution, path, ask_path, sftp_folder, report_md, results_md, email_psswd
+    ctx,
+    type,
+    resolution,
+    path,
+    ask_path,
+    sftp_folder,
+    report_md,
+    results_md,
+    email_psswd,
 ):
     """
     Create the folder documentation structure in bioinfo_doc server
@@ -467,7 +514,7 @@ def bioinfo_doc(
         sftp_folder,
         report_md,
         results_md,
-        ctx.obj["api_user"], 
+        ctx.obj["api_user"],
         ctx.obj["api_password"],
         email_psswd,
     )
@@ -535,7 +582,7 @@ def archive(
         service_file,
         ser_type,
         option,
-        ctx.obj["api_user"], 
+        ctx.obj["api_user"],
         ctx.obj["api_password"],
         skip_prompts,
         date_from,

--- a/bu_isciii/__main__.py
+++ b/bu_isciii/__main__.py
@@ -314,7 +314,12 @@ def clean(ctx, resolution, path, ask_path, option):
     show removable files or show folders for no copy.
     """
     clean = bu_isciii.clean.CleanUp(
-        resolution, path, ask_path, option, ctx.obj["api_user"], ctx.obj["api_password"]
+        resolution, 
+        path, 
+        ask_path, 
+        option, 
+        ctx.obj["api_user"], 
+        ctx.obj["api_password"]
     )
     clean.handle_clean()
 

--- a/bu_isciii/archive.py
+++ b/bu_isciii/archive.py
@@ -35,7 +35,8 @@ class Archive:
         services_file=None,
         ser_type=None,
         option=None,
-        api_token=None,
+        api_user=None,
+        api_password=None,
         skip_prompts=False,
         date_from=None,
         date_until=None,
@@ -80,7 +81,8 @@ class Archive:
         rest_api = bu_isciii.drylab_api.RestServiceApi(
             conf_api["server"],
             conf_api["api_url"],
-            api_token,
+            api_user,
+            api_password,
         )
 
         self.skip_prompts = skip_prompts

--- a/bu_isciii/clean.py
+++ b/bu_isciii/clean.py
@@ -276,7 +276,7 @@ class CleanUp:
         path_content = self.scan_dirs(to_find=to_find)
         unfiltered_path_content = [f.path for f in os.scandir(self.full_path)]
         for directory_to_rename in path_content:
-            renamed_directory = str(directory_to_rename+add)
+            renamed_directory = str(directory_to_rename + add)
             if renamed_directory in unfiltered_path_content:
                 stderr.print(
                     "[orange]WARNING: Directory %s already renamed to %s Omitting..."

--- a/bu_isciii/conf/configuration.json
+++ b/bu_isciii/conf/configuration.json
@@ -52,6 +52,7 @@
             "'service_info.txt'",
             "'work'"
         ],
+        "scratch_path": "/scratch/bi/",
         "srun_settings": {
             "--partition": "middle_idx",
             "--time": "24:00:00",

--- a/bu_isciii/conf/configuration.json
+++ b/bu_isciii/conf/configuration.json
@@ -1,60 +1,65 @@
 {
-    "global":{
-      "data_path": "/data/bi",
-      "archived_path": "/archived/bi",
-      "yaml_conf_path": "~/buisciii_config.yml"
+    "global": {
+        "data_path": "/data/bi",
+        "archived_path": "/archived/bi",
+        "yaml_conf_path": "~/buisciii_config.yml"
     },
     "sftp_copy": {
-      "protocol": "rsync",
-      "options": ["-rlpv", "--update", "-L", "--inplace"],
-      "exclusions": [
-        "'*_NC'",
-        "'lablog'",
-        "'work'",
-        "'00-reads'",
-        "'*.sh'",
-        "'.nextflow*'",
-        "'*_DEL'",
-        "'*.R'",
-        "'*.py'"
-      ]
+        "protocol": "rsync",
+        "options": ["-rlpv", "--update", "-L", "--inplace"],
+        "exclusions": [
+            "'*_NC'",
+            "'lablog'",
+            "'work'",
+            "'00-reads'",
+            "'*.sh'",
+            "'.nextflow*'",
+            "'*_DEL'",
+            "'*.R'",
+            "'*.py'"
+        ]
     },
     "xtutatis_api_settings": {
-      "api_url": "/drylab/api/",
-      "server": "http://iskylimsapi.isciiides.es"
+        "api_url": "/drylab/api/",
+        "server": "http://iskylims.isciiides.es"
     },
     "api_settings": {
         "server": "http://iskylims.isciiides.es",
         "api_url": "/drylab/api/"
     },
     "bioinfo_doc": {
-      "bioinfodoc_path": "/data/bioinfo_doc/",
-      "services_path": "services",
-      "service_folder": ["service_info", "result"],
-      "service_info_template_path_file" : "templates/jinja_template_service_info.j2",
-      "delivery_template_path_file" : "templates/jinja_template_delivery.j2",
-      "html_template_path_file" : "templates/html_service_template.html",
-      "path_to_css" : "assets/css",
-      "wkhtmltopdf_path" : "/data/bi/pipelines/miniconda3/envs/buisciii-tools/bin/wkhtmltopdf",
-      "email_host":"mx2.isciii.es",
-      "email_port" : "587",
-      "email_host_user" : "bioinformatica@isciii.es",
-      "email_use_tls" : "True"
+        "bioinfodoc_path": "/data/bioinfo_doc/",
+        "services_path": "services",
+        "service_folder": ["service_info", "result"],
+        "service_info_template_path_file": "templates/jinja_template_service_info.j2",
+        "delivery_template_path_file": "templates/jinja_template_delivery.j2",
+        "html_template_path_file": "templates/html_service_template.html",
+        "path_to_css": "assets/css",
+        "wkhtmltopdf_path": "/data/bi/pipelines/miniconda3/envs/buisciii-tools/bin/wkhtmltopdf",
+        "email_host": "mx2.isciii.es",
+        "email_port": "587",
+        "email_host_user": "bioinformatica@isciii.es",
+        "email_use_tls": "True"
     },
     "new_service": {
-      "fastq_repo": "/srv/fastq_repo"
+        "fastq_repo": "/srv/fastq_repo"
     },
     "scratch_copy": {
-      "protocol": "rsync",
-      "options": ["-rlpv"],
-      "exclusions": [
-        "'*_NC'",
-        "'service_info.txt'",
-        "'work'"
-      ]
+        "protocol": "rsync",
+        "options": ["-rlpv"],
+        "exclusions": [
+            "'*_NC'",
+            "'service_info.txt'",
+            "'work'"
+        ],
+        "srun_settings": {
+            "--partition": "middle_idx",
+            "--time": "24:00:00",
+            "--chdir": "/scratch/bi/"
+        }
     },
     "archive": {
-      "protocol": "rsync",
-      "options": ["-rv"]
+        "protocol": "rsync",
+        "options": ["-rv"]
     }
 }

--- a/bu_isciii/conf/configuration.json
+++ b/bu_isciii/conf/configuration.json
@@ -1,7 +1,8 @@
 {
     "global":{
       "data_path": "/data/bi",
-      "archived_path": "/archived/bi"
+      "archived_path": "/archived/bi",
+      "yaml_conf_path": "~/buisciii_config.yml"
     },
     "sftp_copy": {
       "protocol": "rsync",

--- a/bu_isciii/copy_sftp.py
+++ b/bu_isciii/copy_sftp.py
@@ -31,7 +31,8 @@ class CopySftp:
         path=None,
         ask_path=False,
         sftp_folder=None,
-        api_token=None,
+        api_user=None,
+        api_password=None,
     ):
         if resolution_id is None:
             self.resolution_id = bu_isciii.utils.prompt_resolution_id()
@@ -46,7 +47,7 @@ class CopySftp:
 
         # Obtain info from iskylims api
         rest_api = bu_isciii.drylab_api.RestServiceApi(
-            conf_api["server"], conf_api["api_url"], api_token
+            conf_api["server"], conf_api["api_url"], api_user, api_password
         )
 
         self.resolution_info = rest_api.get_request(

--- a/bu_isciii/drylab_api.py
+++ b/bu_isciii/drylab_api.py
@@ -22,8 +22,12 @@ class RestServiceApi:
             "accept": "application/json",
             "Content-Type": "application/json"
         }
-        if not user or not password:
-            stderr.print("[red]Missing credentials for api request")
+        if not user:
+            stderr.print("[red]Missing user for api request")
+            bu_isciii.utils.ask_for_some_text("API user: ")
+        if not password:
+            stderr.print("[red]Missing password for api request")
+            bu_isciii.utils.ask_password("User password: ")
         else:
             self.auth = (user, password)
 

--- a/bu_isciii/drylab_api.py
+++ b/bu_isciii/drylab_api.py
@@ -16,12 +16,16 @@ stderr = rich.console.Console(
 
 
 class RestServiceApi:
-    def __init__(self, server, url, password):
+    def __init__(self, server, url, user, password):
         self.request_url = server + url
         self.headers = {
-            "content-type": "application/json",
-            "WWW-Authenticate": "Basic " + password,
+            "accept": "application/json",
+            "Content-Type": "application/json"
         }
+        if not user or not password:
+            stderr.print("[red]Missing credentials for api request")
+        else:
+            self.auth = (user, password)
 
     # TODO: this is waaay too dirty, find a way to pass variable number of parameters and values.
     # by Guille: I used an f-string instead of all the + stuff, I think thats cleaner?
@@ -34,12 +38,13 @@ class RestServiceApi:
                 if safe:
                     log.info(f"Query does not exist. Status code: {req.status_code}")
                     stderr.print("Query not found")
-                    sys.exit()
+                    sys.exit(1)
                 else:
                     return req.status_code
             return json.loads(req.text)
         except requests.ConnectionError:
-            log.error("Unable to open connection towards iSkyLIMS")
+            log.error("Unable to open connection towards iSkyLIMS, aborting")
+            sys.exit(1)
             return False
 
     def put_request(
@@ -58,7 +63,7 @@ class RestServiceApi:
             + value2
         )
         try:
-            req = requests.put(url_http, headers=self.headers)
+            req = requests.put(url_http, headers=self.headers, auth=self.auth)
             if req.status_code > 201:
                 if safe:
                     log.error(
@@ -72,12 +77,13 @@ class RestServiceApi:
             return True
         except requests.ConnectionError:
             log.error("Unable to open connection towards iSkyLIMS")
+            sys.exit(1)
             return False
 
     def post_request(self, request_info, data, safe=True):
         url_http = self.request_url + request_info
         try:
-            req = requests.post(url_http, data=data, headers=self.headers)
+            req = requests.post(url_http, data=data, headers=self.headers, auth=self.auth)
             if req.status_code > 201:
                 if safe:
                     log.error(
@@ -90,9 +96,21 @@ class RestServiceApi:
             return True
 
         except requests.ConnectionError:
-            log.error("Unable to open connection towards iSkyLIMS")
+            log.error("Unable to open connection towards iSkyLIMS, aborting")
+            sys.exit(1)
             return False
-
+ 
+    def basic_authentication(self):
+        # Pseudo-code for credentials validation, returns error 404 right now
+        from requests.auth import HTTPBasicAuth
+        user, password = self.auth[0], self.auth[1]
+        url_http = (self.request_url)
+        response = requests.get(url_http, auth=HTTPBasicAuth(user, password))
+        print("Response status code", response.status_code)
+        if response.status_code <= 200:
+            return True
+        else:
+            return False
 
 """ Example usage
     rest_api = RestServiceApi("http://localhost:8000/", "drylab/api/")

--- a/bu_isciii/drylab_api.py
+++ b/bu_isciii/drylab_api.py
@@ -74,7 +74,7 @@ class RestServiceApi:
                         "Resolution id does not exist. Status code: "
                         + str(req.status_code)
                     )
-                    sys.exit()
+                    sys.exit(1)
                 else:
                     return req.status_code
             # return json.loads(req.text)
@@ -106,7 +106,8 @@ class RestServiceApi:
             sys.exit(1)
             return False
 
-    def basic_authentication(self):
+
+""" def basic_authentication(self):
         # Pseudo-code for credentials validation, returns error 404 right now
         from requests.auth import HTTPBasicAuth
 
@@ -118,7 +119,7 @@ class RestServiceApi:
             return True
         else:
             return False
-
+"""
 
 """ Example usage
     rest_api = RestServiceApi("http://localhost:8000/", "drylab/api/")

--- a/bu_isciii/drylab_api.py
+++ b/bu_isciii/drylab_api.py
@@ -20,7 +20,7 @@ class RestServiceApi:
         self.request_url = server + url
         self.headers = {
             "accept": "application/json",
-            "Content-Type": "application/json"
+            "Content-Type": "application/json",
         }
         if not user:
             stderr.print("[red]Missing user for api request")
@@ -87,7 +87,9 @@ class RestServiceApi:
     def post_request(self, request_info, data, safe=True):
         url_http = self.request_url + request_info
         try:
-            req = requests.post(url_http, data=data, headers=self.headers, auth=self.auth)
+            req = requests.post(
+                url_http, data=data, headers=self.headers, auth=self.auth
+            )
             if req.status_code > 201:
                 if safe:
                     log.error(
@@ -103,18 +105,20 @@ class RestServiceApi:
             log.error("Unable to open connection towards iSkyLIMS, aborting")
             sys.exit(1)
             return False
- 
+
     def basic_authentication(self):
         # Pseudo-code for credentials validation, returns error 404 right now
         from requests.auth import HTTPBasicAuth
+
         user, password = self.auth[0], self.auth[1]
-        url_http = (self.request_url)
+        url_http = self.request_url
         response = requests.get(url_http, auth=HTTPBasicAuth(user, password))
         print("Response status code", response.status_code)
         if response.status_code <= 200:
             return True
         else:
             return False
+
 
 """ Example usage
     rest_api = RestServiceApi("http://localhost:8000/", "drylab/api/")

--- a/bu_isciii/new_service.py
+++ b/bu_isciii/new_service.py
@@ -32,7 +32,8 @@ class NewService:
         path=None,
         no_create_folder=None,
         ask_path=False,
-        api_token=None,
+        api_user=None,
+        api_password=None
     ):
         if resolution_id is None:
             self.resolution_id = bu_isciii.utils.prompt_resolution_id()
@@ -51,7 +52,7 @@ class NewService:
         )
         # Obtain info from iskylims api
         self.rest_api = bu_isciii.drylab_api.RestServiceApi(
-            conf_api["server"], conf_api["api_url"], api_token
+            conf_api["server"], conf_api["api_url"], api_user, api_password
         )
         self.resolution_info = self.rest_api.get_request(
             request_info="service-data", safe=False, resolution=self.resolution_id
@@ -155,7 +156,7 @@ class NewService:
                 "[red] ERROR: I'm not already prepared for handling more than one error at the same time, sorry!"
                 "Please re-run and select one of the service ids."
             )
-            sys.exit()
+            sys.exit(1)
             return False
         return True
 

--- a/bu_isciii/scratch.py
+++ b/bu_isciii/scratch.py
@@ -114,7 +114,7 @@ class Scratch:
                 if protocol == "rsync":
                     rsync_command = sysrsync.get_rsync_command(
                         source=self.full_path,
-                        destination="/scratch/bi/",
+                        destination=self.conf["scratch_path"],
                         options=self.conf["options"],
                         exclusions=self.conf["exclusions"],
                         sync_source_contents=False,
@@ -171,8 +171,10 @@ class Scratch:
             if self.service_folder in dest_folder:
                 try:
                     if self.conf["protocol"] == "rsync":
-                        # /scratch/bi/ is used due to permission issues
-                        scratch_bi_path = "".join("/scratch/bi/", self.service_folder)
+                        # scratch_tmp cannot be used due to permission issues
+                        scratch_bi_path = "".join(
+                            self.conf["scratch_path"], self.service_folder
+                        )
                         rsync_command = sysrsync.get_rsync_command(
                             source=scratch_bi_path,
                             destination=dest_dir,

--- a/bu_isciii/scratch.py
+++ b/bu_isciii/scratch.py
@@ -34,7 +34,8 @@ class Scratch:
         tmp_dir=None,
         direction=None,
         ask_path=False,
-        api_token=None,
+        api_user=None,
+        api_password=None
     ):
         if resolution_id is None:
             self.resolution_id = bu_isciii.utils.prompt_resolution_id()
@@ -53,7 +54,6 @@ class Scratch:
             )
         else:
             self.direction = direction
-
         # Load conf
         conf_api = bu_isciii.config_json.ConfigJson().get_configuration(
             "xtutatis_api_settings"
@@ -62,7 +62,8 @@ class Scratch:
         rest_api = bu_isciii.drylab_api.RestServiceApi(
             conf_api["server"],
             conf_api["api_url"],
-            api_token,
+            api_user,
+            api_password
         )
         self.conf = bu_isciii.config_json.ConfigJson().get_configuration("scratch_copy")
 

--- a/bu_isciii/scratch.py
+++ b/bu_isciii/scratch.py
@@ -119,7 +119,7 @@ class Scratch:
                         exclusions=self.conf["exclusions"],
                         sync_source_contents=False,
                     )
-                    srun_rsync = self.srun_command(self.srun_settings, rsync_command)
+                    self.srun_command(self.srun_settings, rsync_command)
                     stderr.print(
                         "[green] Data copied to the sftp folder successfully",
                         highlight=False,
@@ -180,9 +180,7 @@ class Scratch:
                             exclusions=self.conf["exclusions"],
                             sync_source_contents=False,
                         )
-                        srun_rsync = self.srun_command(
-                            self.srun_settings, rsync_command
-                        )
+                        self.srun_command(self.srun_settings, rsync_command)
                         stderr.print(
                             "[green]Successfully copied the directory to %s"
                             % dest_folder,

--- a/bu_isciii/utils.py
+++ b/bu_isciii/utils.py
@@ -392,7 +392,16 @@ def ask_date(previous_date=None, posterior_date=None, initial_year=2010):
 
 
 def get_yaml_config():
-    """Extract the fields from the config yaml file described in configuration.json"""
+    """Search the config yaml file described in configuration.json and extract fields
+
+    Returns:
+    -------
+        yaml_fields = {
+            "api_user": "User for Iskylims API" (str) ,
+            "api_credentials": "Password to API user" (str) ,
+            "Other keys": "values"
+        }
+    """
     yaml_path = bu_isciii.config_json.ConfigJson().get_find("global", "yaml_conf_path")
     try:
         yaml_file = os.path.expanduser(yaml_path)
@@ -408,7 +417,15 @@ def get_yaml_config():
 
 
 def validate_api_credentials(cred_fields):
-    """Validate that API credentials are present in dictionary"""
+    """Validate that API credentials are present in dictionary
+
+    Parameters:
+    ----------
+        cred_fields (dict): Dictionary containing the fields from yaml config file
+
+    Returns:
+        Bool: True if api_user and api_password are present in the dictionary
+    """
     user, password = cred_fields.get("api_user"), cred_fields.get("api_password")
     if user and password:
         return True
@@ -430,7 +447,14 @@ def validate_api_credentials(cred_fields):
 
 
 def process_yaml_file(yaml_file):
-    """Read the yaml file and return a dictionary with key/value pairs"""
+    """Read a yaml file and return a dictionary with key/value pairs
+
+    Args:
+        yaml_file (str): Path to the file in yaml format
+
+    Returns:
+        dict: Dictionary containing the fields in the yaml file
+    """
     if os.path.exists(yaml_file):
         with open(yaml_file, "r") as cred_file:
             yaml_fields = yaml.safe_load(cred_file)

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ markdown==3.3.6
 pymdown-extensions
 pdfkit
 PyPDF2
+PyYAML


### PR DESCRIPTION
I introduced user and password credentials to authenticate the requests to iskylims API into all the modules.

The main differences are present in:
1. [__main__.py](https://github.com/BU-ISCIII/buisciii-tools/blob/develop/bu_isciii/__main__.py). Buisciii-tools can now be executed using a credentials file in yaml format in the user's home directory; or specify them before the command that is going to be passed to the Command line.
2. [utils.py](https://github.com/BU-ISCIII/buisciii-tools/blob/develop/bu_isciii/utils.py) Received three functions that aim to extract the fields from the yaml file and to verify that the extraction was correct.

The rest of the modules received minor changes such as error handling.

I also included the srun command into the scratch module so the copy process is done using SLURM's queue manager.

Closes #147 