### PR TITLE
New Bacterial Genome Assembly Template: Short, Long, and Hybrid Sequences

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -4,9 +4,9 @@
 
 If you'd like to write or modify some code for buisciii-tools, the standard workflow is as follows:
 
-1. Check that there isn't already an issue about your idea in the [buisciii-tools issues](https://github.com/BU-ISCIII/buisciii-tools/issues) to avoid duplicating work. **If there isn't one already, please create one so that others know you're working on this**
+1. Check that there isn't already an issue about your idea in the [buisciii-tools issues](https://github.com/BU-ISCIII/buisciii-tools/issues) to avoid duplicating work. **If there isn't one already, please create one so that others know you're working on this**.
 2. [Fork](https://help.github.com/en/github/getting-started-with-github/fork-a-repo) the [buisciii-tools repository](https://github.com/BU-ISCIII/buisciii-tools/) to your GitHub account.
-3. Make the necessary changes / additions within your forked repository following the [code style guidelines](#code-style-guidelines)
+3. Make the necessary changes / additions within your forked repository following the [code style guidelines](#code-style-guidelines).
 4. Modify the [`CHANGELOG`](../CHANGELOG.md) file according to your changes in the appropiate section ([X.X.Xhot] or [X.X.Xdev]), you should register your changes regarding:
    1. Added enhancements
    2. Template changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,11 +58,13 @@ Code contributions to the hotfix:
 - [Jaime Ozaez](https://github.com/jaimeozaez)
 - [Sara Monzón](https://github.com/saramonzon)
 - [Sarai Varona](https://github.com/svarona)
+- [Daniel Valle](https://github.com/Daniel-VM)
 
 
 ### Template fixes and updates
 
 - Added new line in `buisciii_tools/bu_isciii/templates/viralrecon/ANALYSIS/lablog_viralrecon`, in order to automatically rename `ANALYSIS0X_MAG` directory with the current date. 
+- [#187](https://github.com/BU-ISCIII/buisciii-tools/pull/187) - Added new template for bacterial assembly. Allowing for short, long and hybrid assembly.
 
 
 ### Modules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,7 @@ Code contributions to the hotfix:
 - Added new line in `buisciii_tools/bu_isciii/templates/viralrecon/ANALYSIS/lablog_viralrecon`, in order to automatically rename `ANALYSIS0X_MAG` directory with the current date. 
 
 
-# Modules
+## Modules
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,7 +63,7 @@ Code contributions to the hotfix:
 
 ### Fixes
 
-- Added new line in 'buisciii_tools/bu_isciii/templates/viralrecon/ANALYSIS/lablog_viralrecon', in order to automatically renamey 'ANALYSIS0X_MAG' directory with the current date.
+- Added new line in `buisciii_tools/bu_isciii/templates/viralrecon/ANALYSIS/lablog_viralrecon`, in order to automatically renamey `ANALYSIS0X_MAG` directory with the current date.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,7 @@ Code contributions to the hotfix:
 - Added new line in `buisciii_tools/bu_isciii/templates/viralrecon/ANALYSIS/lablog_viralrecon`, in order to automatically rename `ANALYSIS0X_MAG` directory with the current date. 
 
 
-#Modules
+# Modules
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,11 +59,14 @@ Code contributions to the hotfix:
 - Added Contributing guidelines
 - Added github action to sync branches
 
-### Template changes 
+## Template fixes and updates
+
+- Added new line in `buisciii_tools/bu_isciii/templates/viralrecon/ANALYSIS/lablog_viralrecon`, in order to automatically rename `ANALYSIS0X_MAG` directory with the current date. 
+
+
+#Modules
 
 ### Fixes
-
-- Added new line in `buisciii_tools/bu_isciii/templates/viralrecon/ANALYSIS/lablog_viralrecon`, in order to automatically renamey `ANALYSIS0X_MAG` directory with the current date.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,8 @@ Code contributions to the hotfix:
 
 ### Fixes
 
+- Added new line in 'buisciii_tools/bu_isciii/templates/viralrecon/ANALYSIS/lablog_viralrecon', in order to automatically renamey 'ANALYSIS0X_MAG' directory with the current date.
+
 ### Changed
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,15 @@ Code contributions to the release:
 - [Pablo Mata](https://github.com/Shettland)
 - [Guillermo Gorines](https://github.com/GuilleGorines)
 
-### Added enhancements
+
+### Template fixes and updates
+- Added templates:
+    - freebayes
+
+
+### Modules
+
+#### Added enhancements
 
 - Added credential parameters: --api_user, --api_password and --cred_file
 - Make modules to create folder's paths automatically from DB
@@ -25,22 +33,20 @@ Code contributions to the release:
 - Added json files: sftp_user.json
 - Added delivery jinja templates
 
-### Template changes
-- Added templates:
-    - freebayes
+#### Fixes
 
-### Fixes
-
-### Changed
+#### Changed
 
 - Fixed API requests to fit in the new database format
 - Updated README
 
-### Removed
+#### Removed
+
 
 ### Requirements
 
 - Added PyYAML
+
 
 ## [1.0.1hot] - 2024-0X-0X : https://github.com/BU-ISCIII/buisciii-tools/releases/tag/1.0.1
 
@@ -53,26 +59,29 @@ Code contributions to the hotfix:
 - [Sara Monzón](https://github.com/saramonzon)
 - [Sarai Varona](https://github.com/svarona)
 
-### Added enhancements
+
+### Template fixes and updates
+
+- Added new line in `buisciii_tools/bu_isciii/templates/viralrecon/ANALYSIS/lablog_viralrecon`, in order to automatically rename `ANALYSIS0X_MAG` directory with the current date. 
+
+
+### Modules
+
+#### Added enhancements
 - Added CHANGELOG
 - Added template for Pull Request
 - Added Contributing guidelines
 - Added github action to sync branches
 
-## Template fixes and updates
+#### Fixes
 
-- Added new line in `buisciii_tools/bu_isciii/templates/viralrecon/ANALYSIS/lablog_viralrecon`, in order to automatically rename `ANALYSIS0X_MAG` directory with the current date. 
+#### Changed
 
+#### Removed
 
-## Modules
-
-### Fixes
-
-### Changed
-
-### Removed
 
 ### Requirements
+
 
 ## [1.0.0] - 2024-01-08 : https://github.com/BU-ISCIII/buisciii-tools/releases/tag/1.0.0
 

--- a/bu_isciii/templates/assembly/ANALYSIS/ANALYSIS01_ASSEMBLY/lablog
+++ b/bu_isciii/templates/assembly/ANALYSIS/ANALYSIS01_ASSEMBLY/lablog
@@ -92,7 +92,6 @@ cat samples_id.txt | while read in; do
     fi
 done >> samplesheet.csv
 
-#module load Nextflow/23.10.0 singularity
 scratch_dir=$(echo $PWD | sed "s/\/data\/bi\/scratch_tmp/\/scratch/g")
 
 cat <<EOF > assembly.sbatch
@@ -105,7 +104,7 @@ cat <<EOF > assembly.sbatch
 #SBATCH --output $(date '+%Y%m%d')_assembly01.log
 #SBATCH --chdir $scratch_dir
 
-#module load Nextflow/23.10.0 singularity
+# module load Nextflow/23.10.0 singularity
 export NXF_OPTS="-Xms500M -Xmx8G"
 
 nextflow run /data/bi/pipelines/nf-core-bacass/main.nf \\

--- a/bu_isciii/templates/assembly/DOC/hpc_slurm_assembly.config
+++ b/bu_isciii/templates/assembly/DOC/hpc_slurm_assembly.config
@@ -5,7 +5,7 @@
 singularity {
         enabled                 = true
         autoMounts              = true
-		singularity.cacheDir    = '/data/bi/pipelines/singularity-images/nf-core-bacass'
+        singularity.cacheDir    = '/data/bi/pipelines/singularity-images'
 }
 
 process {

--- a/bu_isciii/templates/assembly/RESULTS/lablog_assembly_results
+++ b/bu_isciii/templates/assembly/RESULTS/lablog_assembly_results
@@ -10,7 +10,15 @@ cd $DELIVERY_FOLDER/assembly
 ln -s ../../../ANALYSIS/*ASSEMBLY/99-stats/multiqc/multiqc_report.html .
 ln -s ../../../ANALYSIS/*ASSEMBLY/99-stats/summary_assembly_metrics_mqc.csv .
 ln -s ../../../ANALYSIS/*ASSEMBLY/99-stats/kmerfinder_summary.csv .
-ln -s ../../../ANALYSIS/*ASSEMBLY/03-assembly/quast/*/report.html quast_report.html
+ln -s ../../../ANALYSIS/*ASSEMBLY/03-assembly/quast/global_report/report.html quast_global_report.html
+
+# Links to per reference reports
+for dir in ../../../ANALYSIS/*ASSEMBLY/03-assembly/quast/per_reference_reports/*; do
+    base=$(basename "$dir")
+    if compgen -G "$dir" > /dev/null; then
+        ln -s "$dir/report.html" "quast_${base}_report.html"
+    fi
+done
 
 # Links to assemblies
 assembly_dirs=(unicycler dragonflye canu miniasm)


### PR DESCRIPTION
## PR DESCRIPTION
This PR introduces a new template for bacterial genome assembly, covering the assembly of genomes from short, hybrid, and long sequences using the[ nf-core bacass::bu-isciii-develop (forked) ](https://github.com/Daniel-VM/bacass/tree/buisciii-develop) workflow . Consequently, this template will replace the previous "assembly" template, expanding its functionality.

## Major implementations
-  `Lablog_assembly`: Parses `fastq.gz` files, classifying them into short and long reads based on their filenames.
- `Lablog`: 1. Introduces a new colored prompt selection method.; 2. Sets up the sample sheet autonomously based on the user's assembly choice (short, long, hybrid).
- `Hpc_slurm_assembly.config`: Sets up the output folder using nf custom configuration files.
- `Lablog_assembly_results`: Adjusts file selection for export to "./Results."
