### PR TITLE
Small changes in variables names for create_summary_report and fix typo in excel_generator.py

### DIFF
--- a/bu_isciii/autoclean_sftp.py
+++ b/bu_isciii/autoclean_sftp.py
@@ -121,9 +121,9 @@ class AutoremoveSftpService:
                     # Get sftp-service last modification
                     service_finder = LastMofdificationFinder(sftp_service_fullPath)
                     service_last_modification = service_finder.find_last_modification()
-                    self.sftp_services[
-                        sftp_service_fullPath
-                    ] = service_last_modification
+                    self.sftp_services[sftp_service_fullPath] = (
+                        service_last_modification
+                    )
         if len(self.sftp_services) == 0:
             sys.exit(f"No services found in {self.path}")
 

--- a/bu_isciii/templates/viralrecon/ANALYSIS/create_summary_report.sh
+++ b/bu_isciii/templates/viralrecon/ANALYSIS/create_summary_report.sh
@@ -22,18 +22,18 @@ do
 
     reads_hostR1=$(cat ${arr[1]}*/kraken2/${arr[0]}.kraken2.report.txt | grep -v 'unclassified' | cut -f3 | awk '{s+=$1}END{print s}')
     reads_host_x2=$(echo $((reads_hostR1 * 2)) )
-    perc_mapped=$(echo $(awk -v v1=$total_reads -v v2=$reads_host_x2 'BEGIN {print (v2*100)/v1}') )
+    perc_host=$(echo $(awk -v v1=$total_reads -v v2=$reads_host_x2 'BEGIN {print (v2*100)/v1}') )
 
     reads_virus=$(cat ${arr[1]}*/variants/bowtie2/samtools_stats/${arr[0]}.sorted.bam.flagstat | grep '+ 0 mapped' | cut -d ' ' -f1)
     
     unmapped_reads=$(echo $((total_reads - (reads_host_x2+reads_virus))) )
     perc_unmapped=$(echo $(awk -v v1=$total_reads -v v2=$unmapped_reads  'BEGIN {print (v2/v1)*100}') )
 
-    n_count=$(cat %Ns.tab | grep -w ${arr[0]} | grep ${arr[1]} | cut -f2)
+    ns_10x_perc=$(cat %Ns.tab | grep -w ${arr[0]} | grep ${arr[1]} | cut -f2)
 
     missense=$(LC_ALL=C awk -F, '{if($10 >= 0.75)print $0}' ${arr[1]}*/variants/ivar/variants_long_table.csv | grep ^${arr[0]}, | grep 'missense' | wc -l)
 
-    Ns_10x_perc=$(zcat ${arr[1]}*/variants/ivar/consensus/bcftools/${arr[0]}.filtered.vcf.gz | grep -v '^#' | wc -l)
+    vars_in_cons10x=$(zcat ${arr[1]}*/variants/ivar/consensus/bcftools/${arr[0]}.filtered.vcf.gz | grep -v '^#' | wc -l)
 
     lineage=$(cat ${arr[1]}*/variants/ivar/consensus/bcftools/pangolin/${arr[0]}.pangolin.csv | tail -n1 | cut -d ',' -f2)
 
@@ -47,5 +47,5 @@ do
     analysis_date=$(date '+%Y%m%d')
 
     # Introduce data row into output file
-    echo -e "${RUN}\t${USER}\t${HOST}\t${arr[1]}\t${arr[0]}\t$total_reads\t$reads_hostR1\t$reads_host_x2\t$perc_mapped\t$reads_virus\t$reads_virus_perc\t$unmapped_reads\t$perc_unmapped\t$medianDPcov\t$cov10x\t$Ns_10x_perc\t$missense\t$n_count\t$lineage\t$read_length\t$analysis_date" >> mapping_illumina_$(date '+%Y%m%d').tab
+    echo -e "${RUN}\t${USER}\t${HOST}\t${arr[1]}\t${arr[0]}\t$total_reads\t$reads_hostR1\t$reads_host_x2\t$perc_host\t$reads_virus\t$reads_virus_perc\t$unmapped_reads\t$perc_unmapped\t$medianDPcov\t$cov10x\t$vars_in_cons10x\t$missense\t$ns_10x_perc\t$lineage\t$read_length\t$analysis_date" >> mapping_illumina_$(date '+%Y%m%d').tab
 done

--- a/bu_isciii/templates/viralrecon/RESULTS/excel_generator.py
+++ b/bu_isciii/templates/viralrecon/RESULTS/excel_generator.py
@@ -104,7 +104,7 @@ def excel_generator(csv_files: List[str]):
             table["analysis_date"] = pd.to_datetime(
                 table["analysis_date"].astype(str), format="%Y%m%d"
             )
-        elif "assembly" in str(file) or "tsv" in str(file) or "tab" in str(file):
+        elif "assembly" in str(file) or ".tsv" in str(file) or ".tab" in str(file):
             table = pd.read_csv(file, sep="\t", header=0)
         else:
             try:
@@ -163,6 +163,7 @@ def main(args):
         )
     except FileNotFoundError as e:
         print("Not variants_long_table found for ", str(e))
+
     # Create excel files for individual tables
     valid_extensions = [".csv", ".tsv", ".tab"]
     rest_of_csvs = [


### PR DESCRIPTION
I renamed some variables in `create-summary_report` from viralrecon template as their name was misleading and fixed a small typo in regex finding in `excel_generator.py`