### PR TITLE
Bioinfo-doc updates: email password in yml and delivery notes in text file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Code contributions to the hotfix:
 
 ### Template fixes and updates
 
+- Added blast_nt template to services.json
+
 ### Modules
 
 #### Added enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Code contributions to the hotfix:
 
 - [#207](https://github.com/BU-ISCIII/buisciii-tools/pull/207) - Bioinfo-doc updates: email password can be given in buisciii_config.yml and delivery notes in a text file
 
+#### Fixes
+
 #### Changed
 
 #### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Code contributions to the hotfix:
 
 #### Added enhancements
 
-#### Fixes
+- [#207](https://github.com/BU-ISCIII/buisciii-tools/pull/207) - Bioinfo-doc updates: email password can be given in buisciii_config.yml and delivery notes in a text file
 
 #### Changed
 

--- a/bu_isciii/__main__.py
+++ b/bu_isciii/__main__.py
@@ -55,7 +55,7 @@ def run_bu_isciii():
     )
 
     # stderr.print("[green]                                          `._,._,'\n", highlight=False)
-    __version__ = "1.0.1"
+    __version__ = "2.0.0"
     stderr.print(
         "[grey39]    BU-ISCIII-tools version {}".format(__version__), highlight=False
     )
@@ -507,6 +507,7 @@ def bioinfo_doc(
     """
     Create the folder documentation structure in bioinfo_doc server
     """
+    email_pass = email_psswd if email_psswd else ctx.obj.get("email_password")
     new_doc = bu_isciii.bioinfo_doc.BioinfoDoc(
         type,
         resolution,
@@ -517,7 +518,7 @@ def bioinfo_doc(
         results_md,
         ctx.obj["api_user"],
         ctx.obj["api_password"],
-        email_psswd,
+        email_pass,
     )
     new_doc.create_documentation()
 
@@ -564,6 +565,7 @@ def bioinfo_doc(
     default=None,
     help="Tsv output path + filename with archive stats and info",
 )
+@click.pass_context
 def archive(
     ctx,
     service_id,

--- a/bu_isciii/bioinfo_doc.py
+++ b/bu_isciii/bioinfo_doc.py
@@ -275,7 +275,7 @@ class BioinfoDoc:
                     stderr.print(f"File selected: {self.provided_txt}")
                     break
             else:
-                stderr.print("No more attempts left. Delivery notes will be given by prompt")
+                stderr.print("No more attempts. Delivery notes will be given by prompt")
                 self.provided_txt = None
         else:
             self.provided_txt = None

--- a/bu_isciii/templates/services.json
+++ b/bu_isciii/templates/services.json
@@ -321,5 +321,22 @@
       "last_folder":"REFERENCES",
       "delivery_md": "",
       "results_md": ""
+    },
+    "blast_nt": {
+      "label": "",
+      "template": "blast_nt",
+      "url": "",
+      "order": 1,
+      "begin": "",
+      "end": "",
+      "description": "",
+      "clean": {
+        "folders":[],
+        "files":[]
+      },
+      "no_copy": ["RAW", "TMP"],
+      "last_folder":"REFERENCES",
+      "delivery_md": "",
+      "results_md": ""
   }
 }


### PR DESCRIPTION
I included several changes into bioinfo-doc module:
- Email password can now be given in buisciii_config.yml file with the tag "email_password"
- There's a default CC now to receive our own reports to the bioinformatics institutional mail
- Delivery notes can be given using a plain text file, which will be asked via prompt

Also included the version 2.0.0 tag into `__main__.py` and blast_nt into `templates/services.json` 