### PR TITLE
Small fixes in autoclean_sftp and bioinfo-doc. Reverted excel_generator.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Code contributions to the hotfix:
 ### Template fixes and updates
 
 - Added blast_nt template to services.json
+- Included new user to sftp_user.json
 
 ### Modules
 
@@ -22,7 +23,13 @@ Code contributions to the hotfix:
 
 #### Fixes
 
+- Autoclean_sftp does not crash anymore. New argument from 'utils.prompt_yn_question()' in v2.0.0 was missing: 'dflt'
+- Bioinfo-doc now sends email correctly to multiple CCs
+
 #### Changed
+
+- excel_generator.py reverted to last state, now lineage tables are merged when argument -l is given
+- Adapted viralrecon_results lablog to new excel_generator.py argument
 
 #### Removed
 

--- a/bu_isciii/autoclean_sftp.py
+++ b/bu_isciii/autoclean_sftp.py
@@ -68,7 +68,9 @@ class AutoremoveSftpService:
     def __init__(self, path=None, days=14):
         # Parse input path
         if path is None:
-            use_default = bu_isciii.utils.prompt_yn_question("Use default path?: ")
+            use_default = bu_isciii.utils.prompt_yn_question(
+                "Use default path?: ", dflt=False
+            )
             if use_default:
                 data_path = bu_isciii.config_json.ConfigJson().get_configuration(
                     "global"
@@ -149,7 +151,9 @@ class AutoremoveSftpService:
                 "The following services are going to be deleted from the sftp:\n"
                 + service_elements
             )
-            confirm_sftp_delete = bu_isciii.utils.prompt_yn_question("Are you sure?: ")
+            confirm_sftp_delete = bu_isciii.utils.prompt_yn_question(
+                "Are you sure?: ", dflt=False
+            )
             if confirm_sftp_delete:
                 for service in self.marked_services:
                     try:

--- a/bu_isciii/bioinfo_doc.py
+++ b/bu_isciii/bioinfo_doc.py
@@ -631,7 +631,7 @@ class BioinfoDoc:
             server.login(user=email_host_user, password=email_host_password)
         except Exception as e:
             stderr.print("[red] Unable to send e-mail" + e)
-
+        default_cc = "bioinformatica@isciii.es"
         msg = MIMEMultipart("alternative")
         msg["To"] = self.resolution_info["service_user_id"]["email"]
         msg["From"] = email_host_user
@@ -645,7 +645,7 @@ class BioinfoDoc:
         )
         if bu_isciii.utils.prompt_yn_question(
             "Do you want to add any other sender? apart from %s. Note: %s is the default CC."
-            % (self.resolution_info["service_user_id"]["email"], msg["CC"].rstrip(";")),
+            % (self.resolution_info["service_user_id"]["email"], default_cc),
             dflt=False,
         ):
             stderr.print(
@@ -655,9 +655,9 @@ class BioinfoDoc:
         else:
             cc_address = str()
         if cc_address:
-            msg["CC"] = str("bioinformatica@isciii.es;" + str(cc_address))
+            msg["CC"] = str(default_cc + ";" + str(cc_address))
         else:
-            msg["CC"] = "bioinformatica@isciii.es"
+            msg["CC"] = default_cc
         rcpt = msg["CC"].split(";") + [msg["To"]]
         html = MIMEText(html_text, "html")
         msg.attach(html)

--- a/bu_isciii/templates/sftp_user.json
+++ b/bu_isciii/templates/sftp_user.json
@@ -48,5 +48,6 @@
     "sresino": ["Labvirushep"],
     "svaldezate": ["Labtaxonomia"],
     "svazquez": ["Labvirusres"],
-    "ycampos": ["LabUfiecMithocondrial"]
+    "ycampos": ["LabUfiecMithocondrial"],
+    "anadonoso": ["Labenterovirus"]
 }

--- a/bu_isciii/templates/viralrecon/RESULTS/excel_generator.py
+++ b/bu_isciii/templates/viralrecon/RESULTS/excel_generator.py
@@ -4,7 +4,7 @@ import pandas as pd
 from typing import List, Dict
 
 # conda activate viralrecon_report
-"""Standard usage: python excel_generator.py -r ./reference.tmp"""
+"""Standard usage: python excel_generator.py -r ./reference.tmp --merge_lineage_files"""
 """Single csv to excel usage: python excel_generator.py -s csv_file.csv"""
 parser = argparse.ArgumentParser(
     description="Generate excel files from viralrecon results"
@@ -21,6 +21,12 @@ parser.add_argument(
     type=str,
     default="",
     help="Transform a single csv file to excel format. Omit rest of processes",
+)
+parser.add_argument(
+    "-l",
+    "--merge_lineage_files",
+    action='store_true',
+    help="Merge pangolin and nextclade lineage tables",
 )
 args = parser.parse_args()
 
@@ -135,7 +141,7 @@ def main(args):
         ref: str("ref_samples/samples_" + ref + ".tmp") for ref in references
     }
 
-    if len(references) > 1:
+    if args.merge_lineage_files:
         # Merge pangolin and nextclade csv files separatedly and create excel files for them
         merge_lineage_tables(reference_folders, samples_ref_files)
         for reference, folder in reference_folders.items():

--- a/bu_isciii/templates/viralrecon/RESULTS/excel_generator.py
+++ b/bu_isciii/templates/viralrecon/RESULTS/excel_generator.py
@@ -25,7 +25,7 @@ parser.add_argument(
 parser.add_argument(
     "-l",
     "--merge_lineage_files",
-    action='store_true',
+    action="store_true",
     help="Merge pangolin and nextclade lineage tables",
 )
 args = parser.parse_args()

--- a/bu_isciii/templates/viralrecon/RESULTS/viralrecon_results
+++ b/bu_isciii/templates/viralrecon/RESULTS/viralrecon_results
@@ -26,7 +26,7 @@ ln -s ../../ANALYSIS/*/assembly_stats.csv ./assembly_stats.csv
 ln -s ../../ANALYSIS/*/01-PikaVirus-results/all_samples_virus_table_filtered.csv ./pikavirus_table.csv
 
 #conda activate viralrecon_report
-echo "python ./excel_generator.py -r ./references.tmp" > _01_generate_excel_files.sh
+echo "python ./excel_generator.py -r ./references.tmp --merge_lineage_files" > _01_generate_excel_files.sh
 #Cleaning temp files and broken symbolic links
 echo "find . -xtype l -delete" > _02_clean_folders.sh
 echo 'for dir in */; do find ${dir} -xtype l -delete; done' >> _02_clean_folders.sh
@@ -46,3 +46,12 @@ cd variants_annot; cat ../../../ANALYSIS/*/samples_ref.txt | while read in; do a
 cd assembly_spades; rsync -rlv ../../../ANALYSIS/*/*/assembly/spades/rnaviral/*.scaffolds.fa.gz .; gunzip *.scaffolds.fa.gz; cd -
 cd abacas_assembly; cat ../../../ANALYSIS/*/samples_ref.txt | while read in; do arr=($in); ln -s ../../../ANALYSIS/*/*${arr[1]}*/assembly/spades/rnaviral/abacas/${arr[0]}.abacas.fasta ./${arr[0]}_${arr[1]}.abacas.fasta; done; cd -
 ln -s ../../ANALYSIS/*/all_samples_filtered_BLAST_results.xlsx .
+
+"""
+Auxiliar script useful for multiple hosts if samples have pattern to distinguish:
+e.g. HOSTPATTERN = 'MONKEY'
+
+cat ../viralrecon_results | sed 's@../../@../../../@g' | sed 's/entrega01/$HOSTPATTERN_results/g' > results_wgs
+sed -i 's@ANALYSIS/\*/@ANALYSIS/*HOSTPATTERN*/@g' results_wgs.sh
+sed 's/SAMPLEPATTERN/HOSTPATTERN/g' results_wgs > results_gf.sh
+"""


### PR DESCRIPTION
<!--
# bu-isciii tools pull request

Based on nf-core/viralrecon pull request template

Fill in the appropriate checklist below and delete whatever is not relevant.

PRs should be made against the develop of hotfix branch, unless you're preparing a software release.
-->

## PR checklist

- [X] I included small fixes in autoclean_sftp and bioinfo-doc modules that appeared with the new release 2.0.0. Also included a new user in sftp_user.json and reverted excel_generator.py to its previous state with an argument to indicate when to merge lineage tables, as the latest changes were not flexible for those situations where there is no reason to merge them.
- [X] Make sure your code lints (`black and flake8`).
- If a new tamplate was added make sure:
    - [X] Template's schema is added in `templates/services.json`.
    - [X] Template's pipeline's documentation in `assets/reports/md/template.md` is added.
    - [X] Results Documentation in `assets/reports/results/template.md` is updated.
- [X] `CHANGELOG.md` is updated.
- [X] `README.md` is updated (including new tool citations and authors/contributors).
- [X] If you know a new user was added to the SFTP, make sure you added it to `templates/sftp_user.json`
