### PR TITLE
Resolve inconsistent parsing in module autoclean-sftp for certain folders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ Code contributions to the hotfix:
 
 #### Fixes
 
+- Added missing url for service assembly_annotation in module list
+- Autoclean-sftp refined folder name parsing with regex label adjustment 
 - Autoclean_sftp does not crash anymore. New argument from 'utils.prompt_yn_question()' in v2.0.0 was missing: 'dflt'
 - Bioinfo-doc now sends email correctly to multiple CCs
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Output:
 ┏━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
 ┃           Service name ┃ Description                               ┃ Github                                     ┃
 ┡━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
-│    assembly_annotation │ Nextflow assembly pipeline to assemble    │                                            │
+│    assembly_annotation │ Nextflow assembly pipeline to assemble    │ https://github.com/Daniel-VM/bacass/...    │
 │                        │ bacterial genomes                         │                                            │
 │        mtbseq_assembly │ Mycobacterium tuberculosis mapping,       │ https://github.com/ngs-fzb/MTBseq_source   │
 │                        │ variant calling and detection of          │                                            │

--- a/bu_isciii/autoclean_sftp.py
+++ b/bu_isciii/autoclean_sftp.py
@@ -109,7 +109,7 @@ class AutoremoveSftpService:
     def get_sftp_services(self):
         self.sftp_services = {}  # {sftp-service_path : last_update}
         service_pattern = (
-            r"^[SRV][A-Z]+[0-9]+_\d{8}_[A-Z0-9]+_[a-zA-Z]+(?:\.[a-zA-Z]+)?_[a-zA-Z]$"
+            r"^[SRV][A-Z]+[0-9]+_\d{8}_[A-Z0-9.-]+_[a-zA-Z]+(?:\.[a-zA-Z]+)?_[a-zA-Z]$"
         )
 
         stderr.print("[blue]Scanning " + self.path + "...")

--- a/bu_isciii/templates/services.json
+++ b/bu_isciii/templates/services.json
@@ -2,7 +2,7 @@
     "assembly_annotation": {
         "label": "",
         "template": "assembly",
-        "url": "",
+        "url": "https://github.com/Daniel-VM/bacass/tree/buisciii-develop",
         "order": 1,
         "begin": "",
         "end": "",


### PR DESCRIPTION
<!--
# bu-isciii tools pull request

Based on nf-core/viralrecon pull request template

Fill in the appropriate checklist below and delete whatever is not relevant.

PRs should be made against the develop of hotfix branch, unless you're preparing a software release.
-->

## PR checklist

- [X] This comment contains a description of changes (with reason).
- [X] Make sure your code lints (`black and flake8`).
- If a new tamplate was added make sure:
    - [ ] Template's schema is added in `templates/services.json`.
    - [ ] Template's pipeline's documentation in `assets/reports/md/template.md` is added.
    - [ ] Results Documentation in `assets/reports/results/template.md` is updated.
- [X] `CHANGELOG.md` is updated.
- [X] `README.md` is updated (including new tool citations and authors/contributors).
- [ ] If you know a new user was added to the SFTP, make sure you added it to `templates/sftp_user.json`

## PR description

- This should fix #209 
- Added missing url in `services.json`
