### PR TITLE
Empty string bug fix in services.json and 04-irma lablog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ Code contributions to the hotfix:
 - excel_generator.py reverted to last state, now lineage tables are merged when argument -l is given
 - Adapted viralrecon_results lablog to new excel_generator.py argument
 - IRMA/RESULTS now creates a summary of the different types of flu found in irma_stats.txt
-- Updated IRMA executable to new location and reduced threads to 16
+- Updated IRMA to v1.1.4 date 02-2024 and reduced threads to 16
 
 #### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ Code contributions to the hotfix:
 - Autoclean_sftp does not crash anymore. New argument from 'utils.prompt_yn_question()' in v2.0.0 was missing: 'dflt'
 - Bioinfo-doc now sends email correctly to multiple CCs
 - Included a missing sed inside IRMA's 04-irma/lablog
+- Changed singularity mount options in Viralrecon template to fix errors with Nextflow v23.10.0
+
 
 #### Changed
 
@@ -35,6 +37,7 @@ Code contributions to the hotfix:
 - Adapted viralrecon_results lablog to new excel_generator.py argument
 - IRMA/RESULTS now creates a summary of the different types of flu found in irma_stats.txt
 - Updated IRMA to v1.1.4 date 02-2024 and reduced threads to 16
+- IRMA 04-irma/lablog now creates B and C dirs only if those flu-types are present
 
 #### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,13 +27,17 @@ Code contributions to the hotfix:
 - Autoclean-sftp refined folder name parsing with regex label adjustment 
 - Autoclean_sftp does not crash anymore. New argument from 'utils.prompt_yn_question()' in v2.0.0 was missing: 'dflt'
 - Bioinfo-doc now sends email correctly to multiple CCs
+- Included a missing sed inside IRMA's 04-irma/lablog
 
 #### Changed
 
 - excel_generator.py reverted to last state, now lineage tables are merged when argument -l is given
 - Adapted viralrecon_results lablog to new excel_generator.py argument
+- IRMA/RESULTS now creates a summary of the different types of flu found in irma_stats.txt
 
 #### Removed
+
+- Removed empty strings from services.json
 
 ### Requirements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Code contributions to the hotfix:
 - excel_generator.py reverted to last state, now lineage tables are merged when argument -l is given
 - Adapted viralrecon_results lablog to new excel_generator.py argument
 - IRMA/RESULTS now creates a summary of the different types of flu found in irma_stats.txt
+- Updated IRMA executable to new location and reduced threads to 16
 
 #### Removed
 

--- a/bu_isciii/templates/IRMA/ANALYSIS/ANALYSIS01_FLU_IRMA/04-irma/lablog
+++ b/bu_isciii/templates/IRMA/ANALYSIS/ANALYSIS01_FLU_IRMA/04-irma/lablog
@@ -5,7 +5,7 @@ mkdir logs
 
 scratch_dir=$(echo $PWD | sed "s/\/data\/bi\/scratch_tmp/\/scratch/g")
 
-cat ../samples_id.txt | while read in; do echo "srun --partition short_idx --cpus-per-task 32 --mem 35000M --chdir $scratch_dir --time 01:00:00 --output logs/IRMA.${in}.%j.log /data/bi/pipelines/flu-amd/IRMA FLU_AD ../02-preprocessing/${in}/${in}_R1_filtered.fastq.gz ../02-preprocessing/${in}/${in}_R2_filtered.fastq.gz ${in} &"; done > _01_irma.sh
+cat ../samples_id.txt | while read in; do echo "srun --partition short_idx --cpus-per-task 16 --mem 35000M --chdir $scratch_dir --time 01:00:00 --output logs/IRMA.${in}.%j.log /data/bi/pipelines/flu-amd-202402/IRMA FLU_AD ../02-preprocessing/${in}/${in}_R1_filtered.fastq.gz ../02-preprocessing/${in}/${in}_R2_filtered.fastq.gz ${in} &"; done > _01_irma.sh
 
 echo 'bash create_irma_stats.sh' > _02_create_stats.sh
 

--- a/bu_isciii/templates/IRMA/ANALYSIS/ANALYSIS01_FLU_IRMA/04-irma/lablog
+++ b/bu_isciii/templates/IRMA/ANALYSIS/ANALYSIS01_FLU_IRMA/04-irma/lablog
@@ -13,9 +13,9 @@ echo "ls */*HA*.fasta | cut -d '/' -f2 | cut -d '.' -f1 | sort -u | cut -d '_' -
 
 echo "cat HA_types.txt | while read in; do mkdir \${in}; done" >> _03_post_processing.sh
 
-echo "mkdir B" >> _03_post_processing.sh
+echo "if grep -qw 'B__' irma_stats.txt; then mkdir B; fi" >> _03_post_processing.sh
 
-echo "mkdir C" >> _03_post_processing.sh
+echo "if grep -qw 'C__' irma_stats.txt; then mkdir C; fi" >> _03_post_processing.sh
 
 echo "ls */*.fasta | cut -d '/' -f2 | cut -d '.' -f1 | cut -d '_' -f1,2 | sort -u | grep 'A_' > A_fragment_list.txt" >> _03_post_processing.sh
 
@@ -31,5 +31,5 @@ echo 'grep -w 'C__' irma_stats.txt | cut -f1 | while read sample; do cat C_fragm
 
 echo 'cat ../samples_id.txt | while read in; do cat ${in}/*.fasta | sed "s/^>/\>${in}_/g" | sed 's/_H1//g' | sed 's/_H3//g' | sed 's/_N1//g' | sed 's/_N2//g' | sed 's@-@/@g' | sed 's/_A_/_/g' | sed 's/_B_/_/g' | sed 's/_C_/_/g' >> all_samples_completo.txt; done' >> _03_post_processing.sh
 
-echo 'sed -i "s/__//g" irma_stats.txt' >> _03_post_processing.sh
-echo 'sed -i "s/_\t/\t/g" irma_stats.txt' >> _03_post_processing.sh
+echo 'sed "s/__//g" irma_stats.txt > clean_irma_stats.txt' >> _03_post_processing.sh
+echo 'sed "s/_\t/\t/g" irma_stats.txt > clean_irma_stats.txt' >> _03_post_processing.sh

--- a/bu_isciii/templates/IRMA/ANALYSIS/ANALYSIS01_FLU_IRMA/04-irma/lablog
+++ b/bu_isciii/templates/IRMA/ANALYSIS/ANALYSIS01_FLU_IRMA/04-irma/lablog
@@ -29,7 +29,7 @@ echo 'grep -w 'B__' irma_stats.txt | cut -f1 | while read sample; do cat B_fragm
 
 echo 'grep -w 'C__' irma_stats.txt | cut -f1 | while read sample; do cat C_fragment_list.txt | while read fragment; do if test -f ${sample}/${fragment}*.fasta; then cat ${sample}/${fragment}*.fasta | sed "s/^>/\>${sample}_/g" | sed s/_H1//g | sed s/_H3//g | sed s/_N1//g | sed s/_N2//g | sed s@-@/@g | sed s/_C_/_/g ; fi >> C/${fragment}.txt; done; done' >> _03_post_processing.sh
 
-echo 'cat ../samples_id.txt | while read in; do cat ${in}/*.fasta | sed "s/^>/\>${in}_/g" | sed 's/_H1//g' | sed 's/_H3//g' | sed 's/_N1//g' | sed 's/_N2//g' | sed 's@-@/@g' | 's/_A_/_/g' | sed 's/_B_/_/g' | sed 's/_C_/_/g' >> all_samples_completo.txt; done' >> _03_post_processing.sh
+echo 'cat ../samples_id.txt | while read in; do cat ${in}/*.fasta | sed "s/^>/\>${in}_/g" | sed 's/_H1//g' | sed 's/_H3//g' | sed 's/_N1//g' | sed 's/_N2//g' | sed 's@-@/@g' | sed 's/_A_/_/g' | sed 's/_B_/_/g' | sed 's/_C_/_/g' >> all_samples_completo.txt; done' >> _03_post_processing.sh
 
 echo 'sed -i "s/__//g" irma_stats.txt' >> _03_post_processing.sh
 echo 'sed -i "s/_\t/\t/g" irma_stats.txt' >> _03_post_processing.sh

--- a/bu_isciii/templates/IRMA/RESULTS/irma_results
+++ b/bu_isciii/templates/IRMA/RESULTS/irma_results
@@ -8,4 +8,4 @@ ln -s ../../ANALYSIS/*FLU_IRMA/04-irma/all_samples_completo.txt .
 ln -s ../../ANALYSIS/*FLU_IRMA/04-irma/A_H* .
 ln -s ../../ANALYSIS/*FLU_IRMA/04-irma/B .
 ln -s ../../ANALYSIS/*FLU_IRMA/04-irma/C .
-tail -n +2 ../../ANALYSIS/*_FLU_IRMA/04-irma/irma_stats.txt | cut -f4 | sort | uniq -c > flu_type_summary.txt
+tail -n +2 ../../ANALYSIS/*_FLU_IRMA/04-irma/clean_irma_stats.txt | cut -f4 | sort | uniq -c > flu_type_summary.txt

--- a/bu_isciii/templates/IRMA/RESULTS/irma_results
+++ b/bu_isciii/templates/IRMA/RESULTS/irma_results
@@ -8,3 +8,4 @@ ln -s ../../ANALYSIS/*FLU_IRMA/04-irma/all_samples_completo.txt .
 ln -s ../../ANALYSIS/*FLU_IRMA/04-irma/A_H* .
 ln -s ../../ANALYSIS/*FLU_IRMA/04-irma/B .
 ln -s ../../ANALYSIS/*FLU_IRMA/04-irma/C .
+tail -n +2 ../../ANALYSIS/*_FLU_IRMA/04-irma/irma_stats.txt | cut -f4 | sort | uniq -c > flu_type_summary.txt

--- a/bu_isciii/templates/services.json
+++ b/bu_isciii/templates/services.json
@@ -196,7 +196,7 @@
       "url": "https://github.com/GuilleGorines/Seek-Destroy",
       "description": "Simple pipeline for basic quality control, host removal and exploratory analysis of samples.",
       "clean": {
-        "folders":[""],
+        "folders":[],
         "files":[]
       },
       "no_copy": ["RAW", "TMP", "00-reads"],
@@ -212,7 +212,7 @@
       "end": "",
       "description": "",
       "clean": {
-        "folders":[""],
+        "folders":[],
         "files":[]
       },
       "no_copy": ["RAW", "TMP", "00-reads"],
@@ -229,7 +229,7 @@
       "url": "https://github.com/nf-core/mag",
       "description": "Bioinformatics best-practise analysis pipeline for assembly, binning and annotation of metagenomes.",
       "clean": {
-        "folders":[""],
+        "folders":[],
         "files":[]
       },
       "no_copy": ["RAW", "TMP"],

--- a/bu_isciii/templates/viralrecon/DOC/viralrecon_sars.config
+++ b/bu_isciii/templates/viralrecon/DOC/viralrecon_sars.config
@@ -1,7 +1,7 @@
 singularity {
 	enabled = true
 	autoMounts = true
-        runOptions = '-B /data/bi/references/'
+        runOptions = '-B /data/bi/references/ -B /data/bi/pipelines/artic-ncov2019/ -B "$HOME"'
 }
 
 process {

--- a/bu_isciii/templates/viralrecon/RESULTS/viralrecon_results
+++ b/bu_isciii/templates/viralrecon/RESULTS/viralrecon_results
@@ -47,11 +47,8 @@ cd assembly_spades; rsync -rlv ../../../ANALYSIS/*/*/assembly/spades/rnaviral/*.
 cd abacas_assembly; cat ../../../ANALYSIS/*/samples_ref.txt | while read in; do arr=($in); ln -s ../../../ANALYSIS/*/*${arr[1]}*/assembly/spades/rnaviral/abacas/${arr[0]}.abacas.fasta ./${arr[0]}_${arr[1]}.abacas.fasta; done; cd -
 ln -s ../../ANALYSIS/*/all_samples_filtered_BLAST_results.xlsx .
 
-"""
-Auxiliar script useful for multiple hosts if samples have pattern to distinguish:
-e.g. HOSTPATTERN = 'MONKEY'
+#Auxiliar script useful for multiple hosts if samples have pattern to distinguish: e.g. HOSTPATTERN1 = 'MONKEY'
 
-cat ../viralrecon_results | sed 's@../../@../../../@g' | sed 's/entrega01/$HOSTPATTERN_results/g' > results_wgs
-sed -i 's@ANALYSIS/\*/@ANALYSIS/*HOSTPATTERN*/@g' results_wgs.sh
-sed 's/SAMPLEPATTERN/HOSTPATTERN/g' results_wgs > results_gf.sh
-"""
+#cat ../viralrecon_results | sed 's@../../@../../../@g' | sed 's/entrega01/HOSTPATTERN1_results/g' > results_wgs
+#sed -i 's@ANALYSIS/\*/@ANALYSIS/*HOSTPATTERN1*/@g' results_wgs.sh
+#sed 's/HOSTPATTERN1/HOSTPATTERN2/g' results_wgs > results_gf.sh


### PR DESCRIPTION
<!--
# bu-isciii tools pull request

Based on nf-core/viralrecon pull request template

Fill in the appropriate checklist below and delete whatever is not relevant.

PRs should be made against the develop of hotfix branch, unless you're preparing a software release.
-->

## PR checklist

- [X] This comment contains a description of changes (with reason).
- [X] Make sure your code lints (`black and flake8`).
- If a new tamplate was added make sure:
    - [X] Template's schema is added in `templates/services.json`.
    - [X] Template's pipeline's documentation in `assets/reports/md/template.md` is added.
    - [X] Results Documentation in `assets/reports/results/template.md` is updated.
- [X] `CHANGELOG.md` is updated.
- [X] `README.md` is updated (including new tool citations and authors/contributors).
- [X] If you know a new user was added to the SFTP, make sure you added it to `templates/sftp_user.json`

I deleted empty strings `""` inside folders to clean from services.json that were leading to a complete deletion of all the folders in the service if any of those templates were selected. 

I also included a sed that was missing inside 04-irma/lablog's _03_post_processing.sh from IRMA template. Also included a line in RESULTS/lablog to create a summary of the different types of flu that were found inside irma_stats.txt