### PR TITLE
Extenison file (csv to tsv) in lablog_viralrecon_results to match pikavirus table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Code contributions to the new version:
 - [Sarai Varona](https://github.com/svarona)
 - [Daniel Valle](https://github.com/Daniel-VM)
 - [Víctor López](https://github.com/victor5lm)
+- [Juan Ledesma](https://github.com/juanledesma78)
 
 ### Template fixes and updates
 
@@ -43,6 +44,7 @@ Code contributions to the new version:
 - Included annotated tab description in exome-trios markdowns [#273](https://github.com/BU-ISCIII/buisciii-tools/pull/273)
 - Installed all necessary singularity images and modified all templates so that, instead of using conda environments or loaded modules, the corresponding singularity images are used [#272](https://github.com/BU-ISCIII/buisciii-tools/pull/272)
 - Updated sarek version in exomeeb, exometrio and wgstrio templates [#277](https://github.com/BU-ISCIII/buisciii-tools/pull/277)
+- Change of extension file of all_samples_virus_table_filtered (from csv to tsv) in lablog_viralrecon_results [#278](https://github.com/BU-ISCIII/buisciii-tools/pull/278) 
 
 ### Modules
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ Code contributions to the new version:
 - Included annotated tab description in exome-trios markdowns [#273](https://github.com/BU-ISCIII/buisciii-tools/pull/273)
 - Installed all necessary singularity images and modified all templates so that, instead of using conda environments or loaded modules, the corresponding singularity images are used [#272](https://github.com/BU-ISCIII/buisciii-tools/pull/272)
 - Updated sarek version in exomeeb, exometrio and wgstrio templates [#277](https://github.com/BU-ISCIII/buisciii-tools/pull/277)
-- Change of extension file of all_samples_virus_table_filtered (from csv to tsv) in lablog_viralrecon_results [#278](https://github.com/BU-ISCIII/buisciii-tools/pull/278) 
+- Extension file of all_samples_virus_table_filtered (from csv to tsv) in lablog_viralrecon_results changed [#278](https://github.com/BU-ISCIII/buisciii-tools/pull/278) 
 
 ### Modules
 

--- a/bu_isciii/templates/viralrecon/RESULTS/lablog_viralrecon_results
+++ b/bu_isciii/templates/viralrecon/RESULTS/lablog_viralrecon_results
@@ -23,7 +23,7 @@ cat references.tmp | while read in; do ln -s ../../ANALYSIS/*/*${in}*/variants/i
 ln -s ../../ANALYSIS/*_MAG/99-stats/multiqc_report.html ./krona_results.html
 ln -s ../../ANALYSIS/*/mapping_illumina*.tab ./mapping_illumina.csv
 ln -s ../../ANALYSIS/*/assembly_stats.csv ./assembly_stats.csv
-ln -s ../../ANALYSIS/*/01-PikaVirus-results/all_samples_virus_table_filtered.csv ./pikavirus_table.csv
+ln -s ../../ANALYSIS/*/01-PikaVirus-results/all_samples_virus_table_filtered.tsv ./pikavirus_table.tsv
 
 #conda activate viralrecon_report
 echo "python ./excel_generator.py -r ./references.tmp --merge_lineage_files" > _01_generate_excel_files.sh


### PR DESCRIPTION
The extension file of all_samples_virus_table_filtered has been changed from csv to tsv so that the symbolic link pointing pikavirus result table is properly created using lablog_viralrecon_results. 

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] Make sure your code lints (`black and flake8`).
- If a new tamplate was added make sure:
    - [ ] Template's schema is added in `templates/services.json`.
    - [ ] Template's pipeline's documentation in `assets/reports/md/template.md` is added.
    - [ ] Results Documentation in `assets/reports/results/template.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
- [ ] If you know a new user was added to the SFTP, make sure you added it to `templates/sftp_user.json`
