### PR TITLE
Fixed clean module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ Code contributions to the new version:
 #### Fixes
 
 - Fixed archive module. Updated correct header for scout tsv [#258](https://github.com/BU-ISCIII/buisciii-tools/pull/258).
+- Fixed clean module. Corrected purge_files function. Renaming stage moved from clean to rename_nocopy option. Updated services.json file with correct paths for some services. [#280](https://github.com/BU-ISCIII/buisciii-tools/pull/280)
 
 #### Changed
 

--- a/bu_isciii/__main__.py
+++ b/bu_isciii/__main__.py
@@ -307,7 +307,7 @@ def scratch(ctx, resolution, path, tmp_dir, direction, ask_path):
     type=click.Choice(
         [
             "full_clean",
-            "rename_nocopy",
+            "rename",
             "clean",
             "revert_renaming",
             "show_removable",
@@ -317,7 +317,7 @@ def scratch(ctx, resolution, path, tmp_dir, direction, ask_path):
     multiple=False,
     help=(
         "Select what to do inside the cleanning step: full_clean: delete files and folders to clean,"
-        " rename no copy and deleted folders, rename_nocopy: just rename no copy folders, clean: "
+        " rename no copy and deleted folders, rename: just rename folders, clean: "
         "delete files and folders to clean,"
         "revert_renaming: remove no_copy and delete tags,"
         "show_removable: list folders and files to remove "
@@ -447,7 +447,7 @@ def finish(ctx, resolution, path, ask_path, sftp_folder, tmp_dir):
         resolution,
         path,
         ask_path,
-        "rename_nocopy",
+        "rename",
         ctx.obj["api_user"],
         ctx.obj["api_password"],
         ctx.obj["conf"],

--- a/bu_isciii/clean.py
+++ b/bu_isciii/clean.py
@@ -55,7 +55,9 @@ class CleanUp:
         self.services_requested = self.resolution_info["resolutions"][0][
             "available_services"
         ]
-        self.service_samples = [sample_id["sample_name"] for sample_id in self.resolution_info["samples"]]
+        self.service_samples = [
+            sample_id["sample_name"] for sample_id in self.resolution_info["samples"]
+            ]
 
         if ask_path and path is None:
             stderr.print(
@@ -311,9 +313,7 @@ class CleanUp:
             files_to_delete = []
             for sample_info in self.service_samples:
                 for file in self.delete_files:
-                    file_to_delete = file.replace(
-                        "sample_name", sample_info
-                    )
+                    file_to_delete = file.replace("sample_name", sample_info)
                     if file_to_delete not in files_to_delete:
                         files_to_delete.append(file_to_delete)
             path_content = self.scan_dirs(to_find=files_to_delete)
@@ -433,7 +433,7 @@ class CleanUp:
         self.delete()
         self.rename(to_find=self.nocopy, add="_NC", verbose=True)
         if self.delete_folders != "":
-                self.rename(add="_DEL", to_find=self.delete_folders, verbose=True)
+            self.rename(add="_DEL", to_find=self.delete_folders, verbose=True)
 
     def handle_clean(self):
         """

--- a/bu_isciii/clean.py
+++ b/bu_isciii/clean.py
@@ -57,7 +57,7 @@ class CleanUp:
         ]
         self.service_samples = [
             sample_id["sample_name"] for sample_id in self.resolution_info["samples"]
-            ]
+        ]
 
         if ask_path and path is None:
             stderr.print(

--- a/bu_isciii/clean.py
+++ b/bu_isciii/clean.py
@@ -100,7 +100,7 @@ class CleanUp:
                 "Options",
                 [
                     "full_clean",
-                    "rename_nocopy",
+                    "rename",
                     "clean",
                     "revert_renaming",
                     "show_removable",
@@ -445,7 +445,7 @@ class CleanUp:
             self.show_nocopy()
         if self.option == "full_clean":
             self.full_clean()
-        if self.option == "rename_nocopy":
+        if self.option == "rename":
             self.rename(to_find=self.nocopy, add="_NC", verbose=True)
             if self.delete_folders != "":
                 self.rename(add="_DEL", to_find=self.delete_folders, verbose=True)

--- a/bu_isciii/clean.py
+++ b/bu_isciii/clean.py
@@ -369,7 +369,7 @@ class CleanUp:
         else:
             stderr.print("There is no work folder here")
 
-    def delete_rename(self, verbose=True, sacredtexts=["lablog", "logs"], add="_DEL"):
+    def delete(self, verbose=True, sacredtexts=["lablog", "logs"], add="_DEL"):
         """
         Description:
             Remove both files and purge folders defined for the service, and rename to tag.
@@ -428,7 +428,7 @@ class CleanUp:
         Perform and handle the whole cleaning of the service
         """
 
-        self.delete_rename()
+        self.delete()
         self.rename(to_find=self.nocopy, add="_NC", verbose=True)
         if self.delete_folders != "":
             self.rename(add="_DEL", to_find=self.delete_folders, verbose=True)

--- a/bu_isciii/clean.py
+++ b/bu_isciii/clean.py
@@ -371,7 +371,7 @@ class CleanUp:
         else:
             stderr.print("There is no work folder here")
 
-    def delete_rename(self, verbose=True, sacredtexts=["lablog", "logs"], add="_DEL"):
+    def delete(self, verbose=True, sacredtexts=["lablog", "logs"], add="_DEL"):
         """
         Description:
             Remove both files and purge folders defined for the service, and rename to tag.
@@ -430,7 +430,7 @@ class CleanUp:
         Perform and handle the whole cleaning of the service
         """
 
-        self.delete_rename()
+        self.delete()
         self.rename(to_find=self.nocopy, add="_NC", verbose=True)
         if self.delete_folders != "":
                 self.rename(add="_DEL", to_find=self.delete_folders, verbose=True)
@@ -450,6 +450,6 @@ class CleanUp:
             if self.delete_folders != "":
                 self.rename(add="_DEL", to_find=self.delete_folders, verbose=True)
         if self.option == "clean":
-            self.delete_rename()
+            self.delete()
         if self.option == "revert_renaming":
             self.revert_renaming()

--- a/bu_isciii/clean.py
+++ b/bu_isciii/clean.py
@@ -98,7 +98,7 @@ class CleanUp:
                 "Options",
                 [
                     "full_clean",
-                    "rename",
+                    "rename_nocopy",
                     "clean",
                     "revert_renaming",
                     "show_removable",
@@ -369,7 +369,7 @@ class CleanUp:
         else:
             stderr.print("There is no work folder here")
 
-    def delete(self, verbose=True, sacredtexts=["lablog", "logs"], add="_DEL"):
+    def delete_rename(self, verbose=True, sacredtexts=["lablog", "logs"], add="_DEL"):
         """
         Description:
             Remove both files and purge folders defined for the service, and rename to tag.
@@ -390,8 +390,10 @@ class CleanUp:
         # Purge folders
         if self.delete_folders != "":
             self.purge_folders(sacredtexts=sacredtexts, add=add, verbose=verbose)
+            # Rename to tag.
+            self.rename(add=add, to_find=self.delete_folders, verbose=verbose)
         else:
-            stderr.print("No folders to remove")
+            stderr.print("No folders to remove or rename")
         # Purge work
         self.delete_work()
         # Delete files
@@ -428,10 +430,8 @@ class CleanUp:
         Perform and handle the whole cleaning of the service
         """
 
-        self.delete()
+        self.delete_rename()
         self.rename(to_find=self.nocopy, add="_NC", verbose=True)
-        if self.delete_folders != "":
-            self.rename(add="_DEL", to_find=self.delete_folders, verbose=True)
 
     def handle_clean(self):
         """
@@ -443,10 +443,8 @@ class CleanUp:
             self.show_nocopy()
         if self.option == "full_clean":
             self.full_clean()
-        if self.option == "rename":
+        if self.option == "rename_nocopy":
             self.rename(to_find=self.nocopy, add="_NC", verbose=True)
-            if self.delete_folders != "":
-                self.rename(add="_DEL", to_find=self.delete_folders, verbose=True)
         if self.option == "clean":
             self.delete_rename()
         if self.option == "revert_renaming":

--- a/bu_isciii/clean.py
+++ b/bu_isciii/clean.py
@@ -390,10 +390,8 @@ class CleanUp:
         # Purge folders
         if self.delete_folders != "":
             self.purge_folders(sacredtexts=sacredtexts, add=add, verbose=verbose)
-            # Rename to tag.
-            self.rename(add=add, to_find=self.delete_folders, verbose=verbose)
         else:
-            stderr.print("No folders to remove or rename")
+            stderr.print("No folders to remove")
         # Purge work
         self.delete_work()
         # Delete files
@@ -432,6 +430,8 @@ class CleanUp:
 
         self.delete_rename()
         self.rename(to_find=self.nocopy, add="_NC", verbose=True)
+        if self.delete_folders != "":
+            self.rename(add="_DEL", to_find=self.delete_folders, verbose=True)
 
     def handle_clean(self):
         """
@@ -445,6 +445,8 @@ class CleanUp:
             self.full_clean()
         if self.option == "rename_nocopy":
             self.rename(to_find=self.nocopy, add="_NC", verbose=True)
+            if self.delete_folders != "":
+                self.rename(add="_DEL", to_find=self.delete_folders, verbose=True)
         if self.option == "clean":
             self.delete_rename()
         if self.option == "revert_renaming":

--- a/bu_isciii/clean.py
+++ b/bu_isciii/clean.py
@@ -31,6 +31,7 @@ class CleanUp:
         option=None,
         api_user=None,
         api_password=None,
+        conf=None,
     ):
         # access the api with the resolution name to obtain the data
         # ask away if no input given
@@ -40,10 +41,8 @@ class CleanUp:
             self.resolution_id = resolution_id
 
         # Obtain info from iskylims api
-        self.conf = bu_isciii.config_json.ConfigJson().get_configuration("cleanning")
-        conf_api = bu_isciii.config_json.ConfigJson().get_configuration(
-            "xtutatis_api_settings"
-        )
+        self.conf = conf.get_configuration("cleanning")
+        conf_api = conf.get_configuration("xtutatis_api_settings")
         rest_api = bu_isciii.drylab_api.RestServiceApi(
             conf_api["server"], conf_api["api_url"], api_user, api_password
         )
@@ -77,7 +76,10 @@ class CleanUp:
             sys.exit()
         else:
             self.path = bu_isciii.utils.get_service_paths(
-                "services_and_colaborations", self.resolution_info, "non_archived_path"
+                conf,
+                "services_and_colaborations",
+                self.resolution_info,
+                "non_archived_path",
             )
 
         self.full_path = os.path.join(self.path, self.service_folder)

--- a/bu_isciii/clean.py
+++ b/bu_isciii/clean.py
@@ -55,7 +55,7 @@ class CleanUp:
         self.services_requested = self.resolution_info["resolutions"][0][
             "available_services"
         ]
-        self.service_samples = self.resolution_info["samples"]
+        self.service_samples = [sample_id["sample_name"] for sample_id in self.resolution_info["samples"]]
 
         if ask_path and path is None:
             stderr.print(
@@ -94,7 +94,6 @@ class CleanUp:
         self.delete_files = self.get_clean_items(self.services_to_clean, type="files")
         # self.delete_list = [item for item in self.delete_list if item]
         self.nocopy = self.get_clean_items(self.services_to_clean, type="no_copy")
-        self.service_samples = self.resolution_info.get("Samples", None)
 
         if option is None:
             self.option = bu_isciii.utils.prompt_selection(
@@ -313,7 +312,7 @@ class CleanUp:
             for sample_info in self.service_samples:
                 for file in self.delete_files:
                     file_to_delete = file.replace(
-                        "sample_name", sample_info["sample_name"]
+                        "sample_name", sample_info
                     )
                     files_to_delete.append(file_to_delete)
             path_content = self.scan_dirs(to_find=files_to_delete)

--- a/bu_isciii/clean.py
+++ b/bu_isciii/clean.py
@@ -392,10 +392,8 @@ class CleanUp:
         # Purge folders
         if self.delete_folders != "":
             self.purge_folders(sacredtexts=sacredtexts, add=add, verbose=verbose)
-            # Rename to tag.
-            self.rename(add=add, to_find=self.delete_folders, verbose=verbose)
         else:
-            stderr.print("No folders to remove or rename")
+            stderr.print("No folders to remove")
         # Purge work
         self.delete_work()
         # Delete files
@@ -434,6 +432,8 @@ class CleanUp:
 
         self.delete_rename()
         self.rename(to_find=self.nocopy, add="_NC", verbose=True)
+        if self.delete_folders != "":
+                self.rename(add="_DEL", to_find=self.delete_folders, verbose=True)
 
     def handle_clean(self):
         """
@@ -447,6 +447,8 @@ class CleanUp:
             self.full_clean()
         if self.option == "rename_nocopy":
             self.rename(to_find=self.nocopy, add="_NC", verbose=True)
+            if self.delete_folders != "":
+                self.rename(add="_DEL", to_find=self.delete_folders, verbose=True)
         if self.option == "clean":
             self.delete_rename()
         if self.option == "revert_renaming":

--- a/bu_isciii/clean.py
+++ b/bu_isciii/clean.py
@@ -98,7 +98,7 @@ class CleanUp:
                 "Options",
                 [
                     "full_clean",
-                    "rename_nocopy",
+                    "rename",
                     "clean",
                     "revert_renaming",
                     "show_removable",
@@ -443,7 +443,7 @@ class CleanUp:
             self.show_nocopy()
         if self.option == "full_clean":
             self.full_clean()
-        if self.option == "rename_nocopy":
+        if self.option == "rename":
             self.rename(to_find=self.nocopy, add="_NC", verbose=True)
             if self.delete_folders != "":
                 self.rename(add="_DEL", to_find=self.delete_folders, verbose=True)

--- a/bu_isciii/clean.py
+++ b/bu_isciii/clean.py
@@ -31,7 +31,6 @@ class CleanUp:
         option=None,
         api_user=None,
         api_password=None,
-        conf=None,
     ):
         # access the api with the resolution name to obtain the data
         # ask away if no input given
@@ -41,8 +40,10 @@ class CleanUp:
             self.resolution_id = resolution_id
 
         # Obtain info from iskylims api
-        self.conf = conf.get_configuration("cleanning")
-        conf_api = conf.get_configuration("xtutatis_api_settings")
+        self.conf = bu_isciii.config_json.ConfigJson().get_configuration("cleanning")
+        conf_api = bu_isciii.config_json.ConfigJson().get_configuration(
+            "xtutatis_api_settings"
+        )
         rest_api = bu_isciii.drylab_api.RestServiceApi(
             conf_api["server"], conf_api["api_url"], api_user, api_password
         )
@@ -76,10 +77,7 @@ class CleanUp:
             sys.exit()
         else:
             self.path = bu_isciii.utils.get_service_paths(
-                conf,
-                "services_and_colaborations",
-                self.resolution_info,
-                "non_archived_path",
+                "services_and_colaborations", self.resolution_info, "non_archived_path"
             )
 
         self.full_path = os.path.join(self.path, self.service_folder)
@@ -314,7 +312,8 @@ class CleanUp:
                     file_to_delete = file.replace(
                         "sample_name", sample_info
                     )
-                    files_to_delete.append(file_to_delete)
+                    if file_to_delete not in files_to_delete:
+                        files_to_delete.append(file_to_delete)
             path_content = self.scan_dirs(to_find=files_to_delete)
             for file in path_content:
                 os.remove(file)

--- a/bu_isciii/templates/services.json
+++ b/bu_isciii/templates/services.json
@@ -8,8 +8,8 @@
         "end": "",
         "description": "nf-core/bacass:  Simple bacterial assembly and annotation pipeline",
         "clean": {
-          "folders":["01-preprocessing/trimmed_sequences"],
-          "files":[]
+          "folders":[],
+          "files":["01-processing/fastp/*.fastp.fastq.gz"]
         },
         "no_copy": ["RAW", "TMP", "latest"],
         "last_folder":"REFERENCES",

--- a/bu_isciii/templates/services.json
+++ b/bu_isciii/templates/services.json
@@ -25,7 +25,7 @@
         "url": "https://github.com/ngs-fzb/MTBseq_source",
         "description": "Mycobacterium tuberculosis mapping, variant calling and detection of resistance using MTBseq",
         "clean": {
-          "folders":["GATK_Bam", "Bam", "Mpileup"],
+          "folders":["Bam", "Mpileup"],
           "files":["01-processing/fastp/sample_name_1.fastp.fastq.gz", "01-processing/fastp/sample_name_2.fastp.fastq.gz"]
         },
         "no_copy": ["RAW", "TMP"],
@@ -42,7 +42,7 @@
         "url": "https://github.com/ngs-fzb/MTBseq_source",
         "description": "Mycobacterium tuberculosis mapping, variant calling and detection of resistance using MTBseq",
         "clean": {
-          "folders":["GATK_Bam", "Bam", "Mpileup"],
+          "folders":["Bam", "Mpileup"],
           "files":["01-processing/fastp/sample_name_1.fastp.fastq.gz", "01-processing/fastp/sample_name_2.fastp.fastq.gz"]
         },
         "no_copy": ["RAW", "TMP"],

--- a/bu_isciii/templates/services.json
+++ b/bu_isciii/templates/services.json
@@ -146,7 +146,7 @@
         "description": "RNA-seq analysis",
         "clean": {
           "folders":[],
-          "files":[]
+          "files":["star_salmon/sample_name.Aligned.out.bam", "star_salmon/sample_name.Aligned.toTranscriptome.out.bam"]
         },
         "no_copy": ["RAW", "TMP"],
         "last_folder":"RESULTS",

--- a/bu_isciii/templates/services.json
+++ b/bu_isciii/templates/services.json
@@ -9,7 +9,7 @@
         "description": "nf-core/bacass:  Simple bacterial assembly and annotation pipeline",
         "clean": {
           "folders":[],
-          "files":["01-processing/fastp/*.fastp.fastq.gz"]
+          "files":["01-processing/fastp/sample_name_1.fastp.fastq.gz", "01-processing/fastp/sample_name_2.fastp.fastq.gz"]
         },
         "no_copy": ["RAW", "TMP", "latest"],
         "last_folder":"REFERENCES",

--- a/bu_isciii/templates/services.json
+++ b/bu_isciii/templates/services.json
@@ -25,8 +25,8 @@
         "url": "https://github.com/ngs-fzb/MTBseq_source",
         "description": "Mycobacterium tuberculosis mapping, variant calling and detection of resistance using MTBseq",
         "clean": {
-          "folders":["01-preprocessing/trimmed_sequences", "Bam", "Mpileup"],
-          "files":[]
+          "folders":["GATK_Bam", "Bam", "Mpileup"],
+          "files":["01-processing/fastp/sample_name_1.fastp.fastq.gz", "01-processing/fastp/sample_name_2.fastp.fastq.gz"]
         },
         "no_copy": ["RAW", "TMP"],
         "last_folder":"REFERENCES",
@@ -42,8 +42,8 @@
         "url": "https://github.com/ngs-fzb/MTBseq_source",
         "description": "Mycobacterium tuberculosis mapping, variant calling and detection of resistance using MTBseq",
         "clean": {
-          "folders":["01-preprocessing", "Bam", "Mpileup"],
-          "files":[]
+          "folders":["GATK_Bam", "Bam", "Mpileup"],
+          "files":["01-processing/fastp/sample_name_1.fastp.fastq.gz", "01-processing/fastp/sample_name_2.fastp.fastq.gz"]
         },
         "no_copy": ["RAW", "TMP"],
         "last_folder":"REFERENCES",


### PR DESCRIPTION
 Fixed clean module:
- Corrected purge_files function. Now it is able to properly find and remove the files set in services.json for every service.
-  Renaming stage moved from clean to rename_nocopy option in order to avoid non-renamed folders being copied from services_and_colaborations to sftp.
- Updated services.json file with correct file paths and file names for some services.

Closes #199 
Closes #221 
Closes #233 
Related #223

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] Make sure your code lints (`black and flake8`).
- If a new tamplate was added make sure:
    - [ ] Template's schema is added in `templates/services.json`.
    - [ ] Template's pipeline's documentation in `assets/reports/md/template.md` is added.
    - [ ] Results Documentation in `assets/reports/results/template.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
- [ ] If you know a new user was added to the SFTP, make sure you added it to `templates/sftp_user.json`
