### PR TITLE
Fixed autoclean-sftp function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ Code contributions to the new version:
 
 - Fixed archive module. Updated correct header for scout tsv [#258](https://github.com/BU-ISCIII/buisciii-tools/pull/258).
 - Fixed clean module. Corrected purge_files function. Renaming stage moved from clean to rename_nocopy option. Updated services.json file with correct paths for some services. [#280](https://github.com/BU-ISCIII/buisciii-tools/pull/280)
+- Fixed autoclean-sftp function. [#281](https://github.com/BU-ISCIII/buisciii-tools/pull/281)
 
 #### Changed
 

--- a/bu_isciii/__main__.py
+++ b/bu_isciii/__main__.py
@@ -640,6 +640,7 @@ def archive(
     default=14,
     help="Integer, remove files older than a window of `-d [int]` days. Default 14 days.",
 )
+@click.pass_context
 def autoclean_sftp(ctx, sftp_folder, days):
     """Clean old sftp services"""
     sftp_clean = bu_isciii.autoclean_sftp.AutoremoveSftpService(

--- a/tatus
+++ b/tatus
@@ -1,0 +1,2 @@
+* [32mdevelop[m
+  main[m

--- a/tatus
+++ b/tatus
@@ -1,2 +1,0 @@
-* [32mdevelop[m
-  main[m


### PR DESCRIPTION
Restored proper performance of autoclean-sftp funcion by adding @click.pass_context before the function in __main__.py file.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] Make sure your code lints (`black and flake8`).
- If a new tamplate was added make sure:
    - [ ] Template's schema is added in `templates/services.json`.
    - [ ] Template's pipeline's documentation in `assets/reports/md/template.md` is added.
    - [ ] Results Documentation in `assets/reports/results/template.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
- [ ] If you know a new user was added to the SFTP, make sure you added it to `templates/sftp_user.json`
