### PR TITLE
Fixed singularity-images path when updating pangolin database in lablog_viralrecon.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,8 @@ Code contributions to the new version:
 - Included annotated tab description in exome-trios markdowns [#273](https://github.com/BU-ISCIII/buisciii-tools/pull/273)
 - Installed all necessary singularity images and modified all templates so that, instead of using conda environments or loaded modules, the corresponding singularity images are used [#272](https://github.com/BU-ISCIII/buisciii-tools/pull/272)
 - Updated sarek version in exomeeb, exometrio and wgstrio templates [#277](https://github.com/BU-ISCIII/buisciii-tools/pull/277)
-- Extension file of all_samples_virus_table_filtered (from csv to tsv) in lablog_viralrecon_results changed [#278](https://github.com/BU-ISCIII/buisciii-tools/pull/278) 
+- Extension file of all_samples_virus_table_filtered (from csv to tsv) in lablog_viralrecon_results changed [#278](https://github.com/BU-ISCIII/buisciii-tools/pull/278)
+- Fixed singularity-images path when updating pangolin database in lablog_viralrecon. [#282](https://github.com/BU-ISCIII/buisciii-tools/pull/282)
 
 ### Modules
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@ Code contributions to the new version:
 - Installed all necessary singularity images and modified all templates so that, instead of using conda environments or loaded modules, the corresponding singularity images are used [#272](https://github.com/BU-ISCIII/buisciii-tools/pull/272)
 - Updated sarek version in exomeeb, exometrio and wgstrio templates [#277](https://github.com/BU-ISCIII/buisciii-tools/pull/277)
 - Extension file of all_samples_virus_table_filtered (from csv to tsv) in lablog_viralrecon_results changed [#278](https://github.com/BU-ISCIII/buisciii-tools/pull/278)
-- Fixed singularity-images path when updating pangolin database in lablog_viralrecon. [#282](https://github.com/BU-ISCIII/buisciii-tools/pull/282)
+- Fixed singularity-images path when updating pangolin database in lablog_viralrecon. Added line break after prompted input. [#282](https://github.com/BU-ISCIII/buisciii-tools/pull/282)
 
 ### Modules
 

--- a/bu_isciii/templates/viralrecon/ANALYSIS/lablog_viralrecon
+++ b/bu_isciii/templates/viralrecon/ANALYSIS/lablog_viralrecon
@@ -211,7 +211,7 @@ echo_bold "\nPlease specify the type of analysis."
 echo_bold "1. METAGENOMICS"
 echo_bold "2. AMPLICONS"
 while true; do
-    echo -ne "\e[1;38;5;220m"; read -n 1 ANALYSIS_TYPE; tput sgr0
+    echo -ne "\e[1;38;5;220m"; read -n 1 ANALYSIS_TYPE; tput sgr0; echo
     if [ "$ANALYSIS_TYPE" == "1" ]; then
         ANALYSIS_TYPE="METAGENOMIC"
         echo_green "$ANALYSIS_TYPE analysis selected."
@@ -230,7 +230,7 @@ echo_bold "\nPlease specify the method to be performed."
     echo_bold "2. De novo assemby"
     echo_bold "3. Both"
     while true; do
-        echo -ne "\e[1;38;5;220m"; read -n 1 method; tput sgr0
+        echo -ne "\e[1;38;5;220m"; read -n 1 method; tput sgr0; echo
         if [ "$method" == "1" ]; then
             echo_green "Mapping method selected."
             break
@@ -251,7 +251,7 @@ echo_bold "\nPlease specify the method to be performed."
 
 # Setting samples_ref.txt file
 echo
-read -p $'\e[1;37mIs samples_ref.txt file already prepared? [y/N]: \e[1;38;5;220m' -n 1 samples_ref_prepared; tput sgr0
+read -p $'\e[1;37mIs samples_ref.txt file already prepared? [y/N]: \e[1;38;5;220m' -n 1 samples_ref_prepared; tput sgr0; echo
 if [ "$samples_ref_prepared" == "y" ]; then 
     echo -e "File samples_ref.txt READY. \xE2\x9C\x85"
 else
@@ -260,7 +260,7 @@ else
     while [ -z "$host" ] || [ -z "$reference" ] || [ "$answer" = "n" ]; do
         read -p $'\e[1;37mPlease specify the host: \e[1;38;5;220m' host
         read -p $'\e[1;37mPlease specify the reference: \e[1;38;5;220m' reference
-        read -p $'\e[1;37mAre host [\e[1;38;5;220m'"${host^^}"$'\e[1;37m] and reference [\e[1;38;5;220m'"${reference}"$'\e[1;37m] correct? [Y/n]: \e[1;38;5;220m' -n 1 answer; tput sgr0
+        read -p $'\e[1;37mAre host [\e[1;38;5;220m'"${host^^}"$'\e[1;37m] and reference [\e[1;38;5;220m'"${reference}"$'\e[1;37m] correct? [Y/n]: \e[1;38;5;220m' -n 1 answer; tput sgr0; echo
     done
     while read in; do echo -e "${in}\t${reference}\t${host^^}" >> samples_ref.txt; done < samples_id.txt
     echo -e "File samples_ref.txt READY. \xE2\x9C\x85"
@@ -272,7 +272,7 @@ if [ "$ANALYSIS_TYPE" = "METAGENOMIC" ]; then
 
     # Nextclade is able to analyze monkeypox virus
     echo
-    read -p $'\e[1;37mDo the sequences correspond to monkeypox virus (MPV)? [y/N]: \e[1;38;5;220m' -n 1 monkeypox; tput sgr0
+    read -p $'\e[1;37mDo the sequences correspond to monkeypox virus (MPV)? [y/N]: \e[1;38;5;220m' -n 1 monkeypox; tput sgr0; echo
     if [ "$monkeypox" == "y" ]; then
 
         virus_tag='mpox'
@@ -291,7 +291,7 @@ else
     echo_bold "2. RSV"
     echo_bold "3. Other"
     while true; do
-        echo -ne "\e[1;38;5;220m"; read -n 1 virus_tag; tput sgr0
+        echo -ne "\e[1;38;5;220m"; read -n 1 virus_tag; tput sgr0; echo
         if [ "$virus_tag" == "1" ]; then
             virus_tag="sars-cov-2"
             echo_green "${virus_tag^^} virus selected."

--- a/bu_isciii/templates/viralrecon/ANALYSIS/lablog_viralrecon
+++ b/bu_isciii/templates/viralrecon/ANALYSIS/lablog_viralrecon
@@ -65,10 +65,10 @@ update_pangolin() {
         echo -e "Pangolin database is UP TO DATE. \xE2\x9C\x85"
     else
         mkdir "$(date '+%Y%m%d')"
-        srun --partition short_idx singularity run -B ${PWD} /scratch/bi/singularity-images/$latest_version_pangolin pangolin --update-data --datadir ${PWD}/$(date '+%Y%m%d')/
+        srun --partition short_idx singularity run -B ${PWD} /data/bi/pipelines/singularity-images/$latest_version_pangolin pangolin --update-data --datadir ${PWD}/$(date '+%Y%m%d')/
         # log file creation
         echo -e "$(date +'%Y-%m-%d %H:%M:%S')\tmkdir $(date '+%Y%m%d')" >> $(date '+%Y%m%d')/log
-        echo -e "$(date +'%Y-%m-%d %H:%M:%S')\tsrun --partition short_idx singularity run -B ${PWD} /scratch/bi/singularity-images/$latest_version_pangolin pangolin --update-data --datadir ${PWD}/$(date '+%Y%m%d')/)" >> $(date '+%Y%m%d')/log
+        echo -e "$(date +'%Y-%m-%d %H:%M:%S')\tsrun --partition short_idx singularity run -B ${PWD} /data/bi/pipelines/singularity-images/$latest_version_pangolin pangolin --update-data --datadir ${PWD}/$(date '+%Y%m%d')/)" >> $(date '+%Y%m%d')/log
         echo_green "Pangolin database UPDATED."
     fi
     cd -

--- a/tatus
+++ b/tatus
@@ -1,0 +1,2 @@
+* [32mdevelop[m
+  main[m

--- a/tatus
+++ b/tatus
@@ -1,2 +1,0 @@
-* [32mdevelop[m
-  main[m


### PR DESCRIPTION
Fixed singularity-images path when updating pangolin database in lablog_viralrecon.
Added line break after prompted input.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] Make sure your code lints (`black and flake8`).
- If a new tamplate was added make sure:
    - [ ] Template's schema is added in `templates/services.json`.
    - [ ] Template's pipeline's documentation in `assets/reports/md/template.md` is added.
    - [ ] Results Documentation in `assets/reports/results/template.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
- [ ] If you know a new user was added to the SFTP, make sure you added it to `templates/sftp_user.json`
