### PR TITLE
Added files to remove for viralrecon service in services.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ Code contributions to the new version:
 - Fixed autoclean-sftp function. [#281](https://github.com/BU-ISCIII/buisciii-tools/pull/281)
 - Fixed bioinfo_doc.py. Modified it so that this module creates a .pdf file including new-line characters, without merging lines into one single line [#259](https://github.com/BU-ISCIII/buisciii-tools/pull/259).
 - PR [#288](https://github.com/BU-ISCIII/buisciii-tools/pull/288) Fixed updating service's state to in_progress multiple times, related with issue [#285](https://github.com/BU-ISCIII/buisciii-tools/issues/285)
+- Added files to remove for viralrecon service in services.json [#294](https://github.com/BU-ISCIII/buisciii-tools/pull/294)
 
 #### Changed
 

--- a/bu_isciii/templates/services.json
+++ b/bu_isciii/templates/services.json
@@ -129,7 +129,7 @@
         "description": "Viral genome reconstruction analysis for SARS-COV-2 data",
         "clean": {
           "folders":[],
-          "files":["variants/bowtie2/sample_name.sorted.bam","variants/bowtie2/sample_name.sorted.bam.bai"]
+          "files":["variants/bowtie2/sample_name.sorted.bam","variants/bowtie2/sample_name.sorted.bam.bai", "variants/bowtie2/sample_name.ivar_trim.sorted.bam","variants/bowtie2/sample_name.ivar_trim.sorted.bam.bai"]
         },
         "no_copy": ["RAW", "TMP"],
         "last_folder":"RESULTS",


### PR DESCRIPTION
When clean module (or finish function) is executed, it fails to remove files named "sample.name".ivar_trim.sorted.bam and "sample.name".ivar_trim.sorted.bam.bai. This files have been added to services.json.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] Make sure your code lints (`black and flake8`).
- If a new tamplate was added make sure:
    - [ ] Template's schema is added in `templates/services.json`.
    - [ ] Template's pipeline's documentation in `assets/reports/md/template.md` is added.
    - [ ] Results Documentation in `assets/reports/results/template.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
- [ ] If you know a new user was added to the SFTP, make sure you added it to `templates/sftp_user.json`
