### PR TITLE
Added new tool,emmtyper, into `characterization` template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ Code contributions to the new version:
 - Updated assembly, ariba, snippy, amrfinderplus and iqtree templates, removed genomeev and mtbseq_assembly templates and updated services.json [#295](https://github.com/BU-ISCIII/buisciii-tools/pull/295)
 - Changed viralrecon's lablog so that references are available within refgenie [#296](https://github.com/BU-ISCIII/buisciii-tools/pull/296)
 - Updated services.json, mtbseq's lablog, viralrecon's lablog and assembly's config file [#299](https://github.com/BU-ISCIII/buisciii-tools/pull/299)
+- Added lablog to automate gene characterization with emmtyper, including unzipping assemblies. [#300](https://github.com/BU-ISCIII/buisciii-tools/pull/300)
 - Fixed 99-stats (MAG) template. [#301](https://github.com/BU-ISCIII/buisciii-tools/pull/301)
 
 ### Modules

--- a/bu_isciii/templates/characterization/ANALYSIS/ANALYSIS01_CHARACTERIZATION/04-emmtyper/lablog
+++ b/bu_isciii/templates/characterization/ANALYSIS/ANALYSIS01_CHARACTERIZATION/04-emmtyper/lablog
@@ -63,7 +63,7 @@ singularity exec \\
     /data/bi/pipelines/singularity-images/singularity-emmtyper.0.2.0--py_0 emmtyper \\
     -w blast \\
     --keep \\
-    --blast_db "${blastdb_path}/cdc_emm_database29042024" \\
+    --blast_db "\${blastdb_path}/cdc_emm_database29042024" \\
     --percent-identity 95 \\
     --culling-limit 5 \\
     --output 01-typing/results_emmtyper.out \\

--- a/bu_isciii/templates/characterization/ANALYSIS/ANALYSIS01_CHARACTERIZATION/04-emmtyper/lablog
+++ b/bu_isciii/templates/characterization/ANALYSIS/ANALYSIS01_CHARACTERIZATION/04-emmtyper/lablog
@@ -6,7 +6,7 @@ mkdir -p .slurm_logs_NC
 
 # Find all .gz files and write them to a file list
 # TODO: add if to check >1 fasta files are available in assembly results
-find ../../*ANALYSIS*ASSEMBLY/03-assembly/unicycler/*.fasta.gz > data_NC/assembly_file_list.txt
+find ../../*ANALYSIS*ASSEMBLY/*-assembly/unicycler/*.fasta.gz > data_NC/assembly_file_list.txt
 ASSEMBLY_LIST=data_NC/assembly_file_list.txt
 
 # Get the number of files

--- a/bu_isciii/templates/characterization/ANALYSIS/ANALYSIS01_CHARACTERIZATION/04-emmtyper/lablog
+++ b/bu_isciii/templates/characterization/ANALYSIS/ANALYSIS01_CHARACTERIZATION/04-emmtyper/lablog
@@ -1,13 +1,13 @@
 #!/bin/sh
 
 # Create folders
-mkdir -p data_NC
-mkdir -p .slurm_logs_NC
+mkdir -p fasta_inputs
+mkdir -p slurm_logs
 
 # Find all .gz files and write them to a file list
 # TODO: add if to check >1 fasta files are available in assembly results
-find ../../*ANALYSIS*ASSEMBLY/*-assembly/unicycler/*.fasta.gz > data_NC/assembly_file_list.txt
-ASSEMBLY_LIST=data_NC/assembly_file_list.txt
+find ../../*ANALYSIS*ASSEMBLY/*-assembly/unicycler/*.fasta.gz > fasta_inputs/assembly_file_list.txt
+ASSEMBLY_LIST=fasta_inputs/assembly_file_list.txt
 
 # Get the number of files
 num_files=$(wc -l < $ASSEMBLY_LIST)
@@ -25,14 +25,14 @@ cat <<EOF > _00_unzip_jobarray.sbatch
 #SBATCH --partition short_idx
 #SBATCH --array=1-$num_files
 #SBATCH --chdir $scratch_dir
-#SBATCH --output .slurm_logs_NC/slurm-%A_%a.out
-#SBATCH --error .slurm_logs_NC/slurm-%A_%a.err
+#SBATCH --output slurm_logs/slurm-%A_%a.out
+#SBATCH --error slurm_logs/slurm-%A_%a.err
 
 # Get the file to process
 file=\$(sed -n "\${SLURM_ARRAY_TASK_ID}p" $ASSEMBLY_LIST)
 
 # Unzip the file to the destination directory
-gzip -dkc \$file > data_NC/\$(basename "\$file" .gz)
+gzip -dkc \$file > fasta_inputs/\$(basename "\$file" .gz)
 
 EOF
 
@@ -68,7 +68,7 @@ singularity exec \\
     --culling-limit 5 \\
     --output 01-typing/results_emmtyper.out \\
     --output-format verbose \\
-    ./data_NC/*.fasta
+    ./fasta_inputs/*.fasta
 
 mv *.tmp 01-typing/tmps
 

--- a/bu_isciii/templates/characterization/ANALYSIS/ANALYSIS01_CHARACTERIZATION/04-emmtyper/lablog
+++ b/bu_isciii/templates/characterization/ANALYSIS/ANALYSIS01_CHARACTERIZATION/04-emmtyper/lablog
@@ -1,0 +1,78 @@
+#!/bin/sh
+
+# Create folders
+mkdir -p data
+mkdir -p .slurm_logs_NC
+
+# Find all .gz files and write them to a file list
+# TODO: add if to check >1 fasta files are available in assembly results
+# FIXME: set path to assembly files (tmp: assembly template file path)  
+find ../../../../assembly/ANALYSIS/*_ASSEMBLY01/results/assembly/unicycler/*.fasta.gz > data/assembly_file_list.txt
+ASSEMBLY_LIST=data/assembly_file_list.txt
+
+# Get the number of files
+num_files=$(wc -l < $ASSEMBLY_LIST)
+
+scratch_dir=$(echo $PWD | sed "s/\/data\/bi\/scratch_tmp/\/scratch/g")
+
+# STEP 1: Set up jobarray to unzip fasta files
+cat <<EOF > _00_unzip_jobarray.sbatch
+#!/bin/bash
+#SBATCH --job-name=unzip_fasta
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=2
+#SBATCH --mem=8G
+#SBATCH --time=2:00:00
+#SBATCH --partition short_idx
+#SBATCH --array=1-$num_files
+#SBATCH --chdir $scratch_dir
+#SBATCH --output .slurm_logs_NC/slurm-%A_%a.out
+#SBATCH --error .slurm_logs_NC/slurm-%A_%a.err
+
+# Get the file to process
+file=\$(sed -n "\${SLURM_ARRAY_TASK_ID}p" $ASSEMBLY_LIST)
+
+# Unzip the file to the destination directory
+gzip -dkc \$file > data/\$(basename "\$file" .gz)
+
+EOF
+
+# FIXME: symb links to BLAST DATABASE?
+# FIXME: conda & singularity load
+# STEP 2: Setup exe file to perform unzip and emmtyper.
+cat <<EOF > _01_emmtyper.sbatch
+#!/bin/bash
+#SBATCH --job-name emmtyper
+#SBATCH --ntasks 1
+#SBATCH --cpus-per-task 4
+#SBATCH --mem 24G
+#SBATCH --time 4:00:00
+#SBATCH --partition short_idx
+#SBATCH --chdir $scratch_dir
+#SBATCH --output ./$(date '+%Y%m%d')_emmtyper.log
+
+# module load singularity
+# conda activate emmtyper-0.2.0
+
+# create results folder
+mkdir -p 01-typing
+mkdir -p 01-typing/tmps
+
+# Run emmtyper
+emmtyper \\
+    -w blast \\
+    --keep \\
+    --blast_db 'path_to_blastdatabase' \\
+    --percent-identity 95 \\
+    --culling-limit 5 \\
+    --output 01-typing/results_emmtyper.out \\
+    --output-format verbose \\
+    ../data/*.fasta
+
+mv *.tmp 01-typing/tmps
+
+EOF
+
+echo "#!/bin/bash" > _ALLSTEPS_emmtyper.sh
+echo "unzip_job_id=\$(sbatch _00_unzip_jobarray.sbatch | awk '{print \$4}')" >> _ALLSTEPS_emmtyper.sh
+echo "sbatch --dependency=afterok:\${unzip_job_id} _01_emmtyper.sbatch" >> _ALLSTEPS_emmtyper.sh

--- a/bu_isciii/templates/characterization/ANALYSIS/ANALYSIS01_CHARACTERIZATION/04-emmtyper/lablog
+++ b/bu_isciii/templates/characterization/ANALYSIS/ANALYSIS01_CHARACTERIZATION/04-emmtyper/lablog
@@ -1,14 +1,13 @@
 #!/bin/sh
 
 # Create folders
-mkdir -p data
+mkdir -p data_NC
 mkdir -p .slurm_logs_NC
 
 # Find all .gz files and write them to a file list
 # TODO: add if to check >1 fasta files are available in assembly results
-# FIXME: set path to assembly files (tmp: assembly template file path)  
-find ../../../../assembly/ANALYSIS/*_ASSEMBLY01/results/assembly/unicycler/*.fasta.gz > data/assembly_file_list.txt
-ASSEMBLY_LIST=data/assembly_file_list.txt
+find ../../*ANALYSIS*ASSEMBLY/03-assembly/unicycler/*.fasta.gz > data_NC/assembly_file_list.txt
+ASSEMBLY_LIST=data_NC/assembly_file_list.txt
 
 # Get the number of files
 num_files=$(wc -l < $ASSEMBLY_LIST)
@@ -33,11 +32,10 @@ cat <<EOF > _00_unzip_jobarray.sbatch
 file=\$(sed -n "\${SLURM_ARRAY_TASK_ID}p" $ASSEMBLY_LIST)
 
 # Unzip the file to the destination directory
-gzip -dkc \$file > data/\$(basename "\$file" .gz)
+gzip -dkc \$file > data_NC/\$(basename "\$file" .gz)
 
 EOF
 
-# FIXME: symb links to BLAST DATABASE?
 # FIXME: conda & singularity load
 # STEP 2: Setup exe file to perform unzip and emmtyper.
 cat <<EOF > _01_emmtyper.sbatch
@@ -62,13 +60,14 @@ mkdir -p 01-typing/tmps
 emmtyper \\
     -w blast \\
     --keep \\
-    --blast_db 'path_to_blastdatabase' \\
+    --blast_db '/data/bi/references/cdc_emm_blastdb/cdc_emm_database29042024' \\
     --percent-identity 95 \\
     --culling-limit 5 \\
     --output 01-typing/results_emmtyper.out \\
     --output-format verbose \\
-    ../data/*.fasta
+    ./data_NC/*.fasta
 
+mv *emmtyper.log 01-typing/
 mv *.tmp 01-typing/tmps
 
 EOF

--- a/bu_isciii/templates/characterization/ANALYSIS/ANALYSIS01_CHARACTERIZATION/04-emmtyper/lablog
+++ b/bu_isciii/templates/characterization/ANALYSIS/ANALYSIS01_CHARACTERIZATION/04-emmtyper/lablog
@@ -36,7 +36,6 @@ gzip -dkc \$file > data_NC/\$(basename "\$file" .gz)
 
 EOF
 
-# FIXME: conda & singularity load
 # STEP 2: Setup exe file to perform unzip and emmtyper.
 cat <<EOF > _01_emmtyper.sbatch
 #!/bin/bash
@@ -50,28 +49,35 @@ cat <<EOF > _01_emmtyper.sbatch
 #SBATCH --output ./$(date '+%Y%m%d')_emmtyper.log
 
 # module load singularity
-# conda activate emmtyper-0.2.0
 
 # create results folder
 mkdir -p 01-typing
 mkdir -p 01-typing/tmps
+blastdb_path=/data/bi/references/cdc_emm_blastdb
 
 # Run emmtyper
-emmtyper \\
+singularity exec \\
+    --bind ${scratch_dir} \\
+    --bind ${scratch_dir}/../../ \\
+    --bind  \$blastdb_path \\
+    /data/bi/pipelines/singularity-images/singularity-emmtyper.0.2.0--py_0 emmtyper \\
     -w blast \\
     --keep \\
-    --blast_db '/data/bi/references/cdc_emm_blastdb/cdc_emm_database29042024' \\
+    --blast_db "${blastdb_path}/cdc_emm_database29042024" \\
     --percent-identity 95 \\
     --culling-limit 5 \\
     --output 01-typing/results_emmtyper.out \\
     --output-format verbose \\
     ./data_NC/*.fasta
 
-mv *emmtyper.log 01-typing/
 mv *.tmp 01-typing/tmps
 
 EOF
 
+# Bash script that performs all steps above
 echo "#!/bin/bash" > _ALLSTEPS_emmtyper.sh
+echo "# # module load singularity" >> _ALLSTEPS_emmtyper.sh
 echo "unzip_job_id=\$(sbatch _00_unzip_jobarray.sbatch | awk '{print \$4}')" >> _ALLSTEPS_emmtyper.sh
 echo "sbatch --dependency=afterok:\${unzip_job_id} _01_emmtyper.sbatch" >> _ALLSTEPS_emmtyper.sh
+
+chmod +x _ALLSTEPS_emmtyper.sh

--- a/bu_isciii/templates/characterization/ANALYSIS/ANALYSIS01_CHARACTERIZATION/04-emmtyper/lablog
+++ b/bu_isciii/templates/characterization/ANALYSIS/ANALYSIS01_CHARACTERIZATION/04-emmtyper/lablog
@@ -2,7 +2,7 @@
 
 # Create folders
 mkdir -p fasta_inputs
-mkdir -p slurm_logs
+mkdir -p logs
 
 # Find all .gz files and write them to a file list
 # TODO: add if to check >1 fasta files are available in assembly results
@@ -25,8 +25,8 @@ cat <<EOF > _00_unzip_jobarray.sbatch
 #SBATCH --partition short_idx
 #SBATCH --array=1-$num_files
 #SBATCH --chdir $scratch_dir
-#SBATCH --output slurm_logs/slurm-%A_%a.out
-#SBATCH --error slurm_logs/slurm-%A_%a.err
+#SBATCH --output logs/slurm-%A_%a.out
+#SBATCH --error logs/slurm-%A_%a.err
 
 # Get the file to process
 file=\$(sed -n "\${SLURM_ARRAY_TASK_ID}p" $ASSEMBLY_LIST)

--- a/bu_isciii/templates/characterization/RESULTS/lablog_characterization_results
+++ b/bu_isciii/templates/characterization/RESULTS/lablog_characterization_results
@@ -1,6 +1,7 @@
 DELIVERY_FOLDER="$(date '+%Y%m%d')_entrega01"
 
 mkdir -p "${DELIVERY_FOLDER}/characterization/amrfinderplus"
+mkdir -p "${DELIVERY_FOLDER}/characterization/emmtyper"
 
 # ARIBA characterization service
 cd $DELIVERY_FOLDER/characterization
@@ -11,4 +12,7 @@ cd amrfinderplus
 ln -s ../../../../ANALYSIS/*CHARACTERIZATION/*amrfinderplus/*tsv .
 find .. -xtype l -delete
 
-cd ../..
+cd ../emmtyper
+ln -s ../../../../ANALYSIS/*CHARACTERIZATION/*emmtyper/01-typing/results_emmtyper.out .
+
+cd ../../

--- a/bu_isciii/templates/characterization/RESULTS/lablog_characterization_results
+++ b/bu_isciii/templates/characterization/RESULTS/lablog_characterization_results
@@ -12,7 +12,8 @@ cd amrfinderplus
 ln -s ../../../../ANALYSIS/*CHARACTERIZATION/*amrfinderplus/*tsv .
 find .. -xtype l -delete
 
-cd ../emmtyper
+cd ..
+cd emmtyper
 ln -s ../../../../ANALYSIS/*CHARACTERIZATION/*emmtyper/01-typing/results_emmtyper.out .
 
 cd ../../

--- a/bu_isciii/templates/services.json
+++ b/bu_isciii/templates/services.json
@@ -198,7 +198,7 @@
         "folders":[],
         "files":[]
       },
-      "no_copy": ["RAW", "TMP", "00-reads"],
+      "no_copy": ["RAW", "TMP", "00-reads", "fasta_inputs"],
       "last_folder":"REFERENCES",
       "delivery_md": "",
       "results_md": ""


### PR DESCRIPTION
<!--
# bu-isciii tools pull request

Based on nf-core/viralrecon pull request template

Fill in the appropriate checklist below and delete whatever is not relevant.

PRs should be made against the develop of hotfix branch, unless you're preparing a software release.
-->

## PR checklist

- [X] This comment contains a description of changes (with reason).
- [X] Make sure your code lints (`black and flake8`).
- If a new tamplate was added make sure:
    - [ ] Template's schema is added in `templates/services.json`.
    - [ ] Template's pipeline's documentation in `assets/reports/md/template.md` is added.
    - [ ] Results Documentation in `assets/reports/results/template.md` is updated.
- [X] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
- [ ] If you know a new user was added to the SFTP, make sure you added it to `templates/sftp_user.json`

## PR description
Added a lablog that generates all required bash and SLURM scripts to perform the characterization of genes encoding the protein emm with [emmtyper](https://github.com/MDU-PHL/emmtyper):

0. Jobarray to uncompress assemblies (*.fasta.gz) from assembly template.
1. Slurm script to perform emmtyper analysis.

 ALL. Script to run both 0,1
(singularity dependency added)

