### PR TITLE
Lablog_viralrecon is now able to download references from ncbi that don't belong to any family

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ Code contributions to the new version:
 - Fixed IRMA's lablog so that the sequences of the samples are not displayed several times neither in the .txt files of each influenza type nor in all_samples_completo.txt [#305](https://github.com/BU-ISCIII/buisciii-tools/pull/305)
 - Modified bioinfo_doc.py so that new lines in the delivery message are applied in the email [#307](https://github.com/BU-ISCIII/buisciii-tools/pull/307)
 - Added several improvements in lablog_viralrecon (created log files, modified check_references function behaviour, enabled config files regeneration) [#306](https://github.com/BU-ISCIII/buisciii-tools/pull/306)
+- Fixed bug when lablog_viralrecon tries to download references that don't belong to any family. [#310](https://github.com/BU-ISCIII/buisciii-tools/pull/310)
 
 ### Modules
 

--- a/bu_isciii/templates/viralrecon/ANALYSIS/lablog_viralrecon
+++ b/bu_isciii/templates/viralrecon/ANALYSIS/lablog_viralrecon
@@ -182,6 +182,11 @@ check_references() {
         family=$(curl -s "https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=${organism_id}" | grep -o 'TITLE="family">.*<' | awk -F 'TITLE="family">' '{print $2}' | cut -d '<' -f 1 | tr '[:upper:]' '[:lower:]')
         if [ -z $family ]; then
             family=$(curl -s "https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=${organism_id}" | grep -o 'ALT="family">.*<' | awk -F 'ALT="family">' '{print $2}' | cut -d '<' -f 1 | tr '[:upper:]' '[:lower:]')
+            if [ -z $family ]; then
+                family="miscellanous"
+                log_message "Reference $ref does not currently belong to any family. Assigned to $family."
+                break
+            fi
         fi
         log_message "Reference $ref belongs to $family family."
     }

--- a/bu_isciii/templates/viralrecon/ANALYSIS/lablog_viralrecon
+++ b/bu_isciii/templates/viralrecon/ANALYSIS/lablog_viralrecon
@@ -260,7 +260,7 @@ check_references() {
             digest=$(openssl rand -hex 24)
             refgenie alias set --aliases ${family} --digest ${digest} -f -c /data/bi/references/refgenie/genome_config.yaml
             mkdir -p /data/bi/references/refgenie/data/${digest}/ensembl_rb/${ref}/
-            wget -q -O "/data/bi/references/refgenie/data/${digest}/ensembl_rb/${ref}/${ref}.gff" "https://www.ncbi.nlm.nih.gov/sviewer/viewer.cgi?db=nuccore&report=gff3&id=${ref}"
+            wget -q -O "/data/bi/references/refgenie/data/${digest}/ensembl_rb/${ref}/${family}.gff" "https://www.ncbi.nlm.nih.gov/sviewer/viewer.cgi?db=nuccore&report=gff3&id=${ref}"
             if [ $? -eq 0 ]; then
                 log_message "File ${ref}.gff downloaded in /data/bi/references/refgenie/data/${digest}/ensembl_rb/${ref}." green
                 log_message "Adding asset for ${ref}.gff file..."
@@ -279,7 +279,7 @@ check_references() {
             log_message "Directory /data/bi/references/refgenie/alias/${family}/ ALREADY EXISTS. Downloading ${ref}.gff."
             digest=$(refgenie alias get -a ${family} -c /data/bi/references/refgenie/genome_config.yaml)
             mkdir -p /data/bi/references/refgenie/data/${digest}/ensembl_rb/${ref}/
-            wget -q -O "/data/bi/references/refgenie/data/${digest}/ensembl_rb/${ref}/${ref}.gff" "https://www.ncbi.nlm.nih.gov/sviewer/viewer.cgi?db=nuccore&report=gff3&id=${ref}"
+            wget -q -O "/data/bi/references/refgenie/data/${digest}/ensembl_rb/${ref}/${family}.gff" "https://www.ncbi.nlm.nih.gov/sviewer/viewer.cgi?db=nuccore&report=gff3&id=${ref}"
             if [ $? -eq 0 ]; then 
                 log_message "File ${ref}.gff downloaded in /data/bi/references/refgenie/data/${digest}/ensembl_rb/${ref}." green
                 log_message "Adding asset for ${ref}.gff file..."

--- a/bu_isciii/templates/viralrecon/ANALYSIS/lablog_viralrecon
+++ b/bu_isciii/templates/viralrecon/ANALYSIS/lablog_viralrecon
@@ -528,4 +528,4 @@ rm percentajeNs.py
 rm _02_create_run_percentage_Ns.sh
 cd 00-reads; cat ../samples_id.txt | xargs -I % echo "ln -s ../../RAW/%_*R1*.fastq.gz %_R1.fastq.gz" | bash; cat ../samples_id.txt | xargs -I % echo "ln -s ../../RAW/%_*R2*.fastq.gz %_R2.fastq.gz" | bash; cd ..
 
-log_message "Lablog_viralrecon execution has been completed. Please verify all the configurations are set up correctly." green
+log_message "Lablog_viralrecon execution has been completed. Please verify all the configurations are set up correctly." bold

--- a/bu_isciii/templates/viralrecon/ANALYSIS/lablog_viralrecon
+++ b/bu_isciii/templates/viralrecon/ANALYSIS/lablog_viralrecon
@@ -214,8 +214,8 @@ check_references() {
                 log_message "File ${ref}.fasta downloaded in /data/bi/references/refgenie/data/${digest}/fasta/${ref}." green
                 gzip /data/bi/references/refgenie/data/${digest}/fasta/${ref}/${ref}.fasta
                 log_message "Building asset for ${ref}.fasta file..."
-                srun --partition short_idx --output ${ref}.fasta_build.log refgenie build ${family}/fasta:${ref} --files fasta=/data/bi/references/refgenie/data/${digest}/fasta/${ref}/${ref}.fasta.gz -c /data/bi/references/refgenie/genome_config.yaml -R
-                if [ $? -eq 0 ]; then
+                refgenie build ${family}/fasta:${ref} --files fasta=/data/bi/references/refgenie/data/${digest}/fasta/${ref}/${ref}.fasta.gz -c /data/bi/references/refgenie/genome_config.yaml -R > ${ref}.fasta_build.log 2>&1
+                if grep -q "Created" "${ref}.fasta_build.log"; then
                     log_message "$(grep Created ${ref}.fasta_build.log) $(grep "/data/bi/references/refgenie/alias/" ${ref}.fasta_build.log)" bold
                     bash /data/bi/references/refgenie/alias/ref.sh
                     REF_FASTA=$(awk -v ref="$ref" '$0 ~ ref && /fasta/ {print $4}' /data/bi/references/refgenie/alias/references.txt)
@@ -234,8 +234,8 @@ check_references() {
                 log_message "File ${ref}.fasta downloaded in /data/bi/references/refgenie/data/${digest}/fasta/${ref}." green
                 gzip /data/bi/references/refgenie/data/${digest}/fasta/${ref}/${ref}.fasta
                 log_message "Building asset for ${ref}.fasta file..."
-                srun --partition short_idx --output ${ref}.fasta_build.log refgenie build ${family}/fasta:${ref} --files fasta=/data/bi/references/refgenie/data/${digest}/fasta/${ref}/${ref}.fasta.gz -c /data/bi/references/refgenie/genome_config.yaml -R
-                if [ $? -eq 0 ]; then
+                refgenie build ${family}/fasta:${ref} --files fasta=/data/bi/references/refgenie/data/${digest}/fasta/${ref}/${ref}.fasta.gz -c /data/bi/references/refgenie/genome_config.yaml -R > ${ref}.fasta_build.log 2>&1
+                if grep -q "Created" "${ref}.fasta_build.log"; then
                     log_message "$(grep Created ${ref}.fasta_build.log) $(grep "/data/bi/references/refgenie/alias/" ${ref}.fasta_build.log)" bold
                     bash /data/bi/references/refgenie/alias/ref.sh
                     REF_FASTA=$(awk -v ref="$ref" '$0 ~ ref && /fasta/ {print $4}' /data/bi/references/refgenie/alias/references.txt)
@@ -264,8 +264,8 @@ check_references() {
             if [ $? -eq 0 ]; then
                 log_message "File ${ref}.gff downloaded in /data/bi/references/refgenie/data/${digest}/ensembl_rb/${ref}." green
                 log_message "Adding asset for ${ref}.gff file..."
-                srun --partition short_idx --output ${ref}.gff_add.log refgenie add ${family}/gff:${ref} --path data/${digest}/ensembl_rb/${ref}/ --seek-keys '{"gff" : "'"${family}.gff"'"}' -c /data/bi/references/refgenie/genome_config.yaml
-                if [ $? -eq 0 ]; then
+                refgenie add ${family}/gff:${ref} --path data/${digest}/ensembl_rb/${ref}/ --seek-keys '{"gff" : "'"${family}.gff"'"}' -c /data/bi/references/refgenie/genome_config.yaml > ${ref}.gff_add.log 2>&1
+                if grep -q "Created" "${ref}.gff_add.log"; then
                     log_message "$(grep Created ${ref}.gff_add.log) $(grep "/data/bi/references/refgenie/alias/" ${ref}.gff_add.log)" bold
                     bash /data/bi/references/refgenie/alias/ref.sh
                     REF_GFF=$(awk -v ref="$ref" '$0 ~ ref && /gff/ {print $4}' /data/bi/references/refgenie/alias/references.txt)
@@ -283,8 +283,8 @@ check_references() {
             if [ $? -eq 0 ]; then 
                 log_message "File ${ref}.gff downloaded in /data/bi/references/refgenie/data/${digest}/ensembl_rb/${ref}." green
                 log_message "Adding asset for ${ref}.gff file..."
-                srun --partition short_idx --output ${ref}.gff_add.log refgenie add ${family}/gff:${ref} --path data/${digest}/ensembl_rb/${ref}/ --seek-keys '{"gff" : "'"${family}.gff"'"}' -c /data/bi/references/refgenie/genome_config.yaml
-                if [ $? -eq 0 ]; then
+                refgenie add ${family}/gff:${ref} --path data/${digest}/ensembl_rb/${ref}/ --seek-keys '{"gff" : "'"${family}.gff"'"}' -c /data/bi/references/refgenie/genome_config.yaml > ${ref}.gff_add.log 2>&1
+                if grep -q "Created" "${ref}.gff_add.log"; then
                     log_message "$(grep Created ${ref}.gff_add.log) $(grep "/data/bi/references/refgenie/alias/" ${ref}.gff_add.log)" bold
                     bash /data/bi/references/refgenie/alias/ref.sh
                     REF_GFF=$(awk -v ref="$ref" '$0 ~ ref && /gff/ {print $4}' /data/bi/references/refgenie/alias/references.txt)

--- a/bu_isciii/templates/viralrecon/ANALYSIS/lablog_viralrecon
+++ b/bu_isciii/templates/viralrecon/ANALYSIS/lablog_viralrecon
@@ -185,7 +185,7 @@ check_references() {
             if [ -z $family ]; then
                 family="miscellanous"
                 log_message "Reference $ref does not currently belong to any family. Assigned to $family."
-                break
+                return
             fi
         fi
         log_message "Reference $ref belongs to $family family."

--- a/bu_isciii/templates/viralrecon/ANALYSIS/lablog_viralrecon
+++ b/bu_isciii/templates/viralrecon/ANALYSIS/lablog_viralrecon
@@ -205,6 +205,15 @@ check_references() {
             log_message "SAMtools module not loaded. Exiting..." blk_red
             exit 1
         fi
+        eval "$(micromamba shell hook --shell bash)"
+        micromamba activate refgenie_v0.12.1
+        environment=$(micromamba info | awk '/environment/ && /active/ {print $3}')
+        if [[ $environment == *"refgenie"* ]]; then
+            log_message "$environment environment succesfully activated." green
+        else
+            log_message "Refgenie environment is NOT ACTIVE. Exiting..." blk_red
+            exit 1
+        fi
         if [ ! -e "/data/bi/references/refgenie/alias/${family}" ]; then # Check if directory doesn't exists
             log_message "Creating new directory: /data/bi/references/refgenie/alias/${family}/ and saving file ${ref}.fasta in /data/bi/references/refgenie/alias/${family}/fasta/${ref}."
             digest=$(openssl rand -hex 24)
@@ -255,6 +264,16 @@ check_references() {
     if [ -z "$REF_GFF" ]; then
         log_message "File ${ref}.gff is not yet downloaded."
         if [ ! -v family ]; then obtain_family; if [ -z ${family} ]; then return; fi; fi
+        if [[ $environment != *"refgenie"* ]]; then
+            eval "$(micromamba shell hook --shell bash)"
+            micromamba activate refgenie_v0.12.1
+            environment=$(micromamba info | awk '/environment/ && /active/ {print $3}')
+            if [[ $environment == *"refgenie"* ]]; then
+                log_message "$environment environment succesfully activated." green
+            else
+                log_message "Refgenie environment is NOT ACTIVE. Exiting..." blk_red
+            fi
+        fi
         if [ ! -e "/data/bi/references/refgenie/alias/${family}" ]; then # Check if directory doesn't exist
             log_message "Creating new directory: /data/bi/references/refgenie/alias/${family}/ and saving file ${ref}.gff in /data/bi/references/refgenie/alias/${family}/gff/${ref}."
             digest=$(openssl rand -hex 24)


### PR DESCRIPTION
Lablog viralrecon tries to identify to which family all new references to be downloaded belong. If the reference does not belong to any family, it fails.
Now, references that do not belong to any family are stored in "miscellaneous" folder.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] Make sure your code lints (`black and flake8`).
- If a new tamplate was added make sure:
    - [ ] Template's schema is added in `templates/services.json`.
    - [ ] Template's pipeline's documentation in `assets/reports/md/template.md` is added.
    - [ ] Results Documentation in `assets/reports/results/template.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
- [ ] If you know a new user was added to the SFTP, make sure you added it to `templates/sftp_user.json`
