### PR TITLE
Updated bioinfo_doc.py, jinja_template_delivery.j2 and services.json to include versions.yml in the delivery .pdf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ Code contributions to the new version:
 - Added bbaladron to SFTP users [#316](https://github.com/BU-ISCIII/buisciii-tools/pull/316).
 - Added new template for comprehensive taxonomy profiling using the nf-core/taxprofiler pipeline [#320](https://github.com/BU-ISCIII/buisciii-tools/pull/320).
 - Added full execution support for the MAG template [#321](https://github.com/BU-ISCIII/buisciii-tools/pull/321).
+- Added labels to services.json and updated bioinfo_doc.py and jinja_template_delivery.j2 so that software versions data is displayed in the delivery pdf [#330](https://github.com/BU-ISCIII/buisciii-tools/pull/330).
 
 ### Modules
 

--- a/bu_isciii/bioinfo_doc.py
+++ b/bu_isciii/bioinfo_doc.py
@@ -212,7 +212,7 @@ class BioinfoDoc:
             service_list = {}
             for service_id_requested in self.service_ids_requested_list:
                 service_list[service_id_requested] = bu_isciii.service_json.ServiceJson().get_find(service_id_requested, "label")
-            self.all_services = service_list 
+            self.all_services = service_list
 
     def load_versions(self):
         """Load and parse the versions.yml file."""

--- a/bu_isciii/bioinfo_doc.py
+++ b/bu_isciii/bioinfo_doc.py
@@ -78,7 +78,7 @@ class BioinfoDoc:
             conf_api["server"], conf_api["api_url"], api_user, api_password
         )
         self.resolution_info = self.rest_api.get_request(
-            request_info="service-data", safe=False, resolution=self.resolution_id
+            request_info="service-data", safe=True, resolution=self.resolution_id
         )
         if self.resolution_info == 404:
             print("Received Error 404 from Iskylims API. Aborting")
@@ -93,7 +93,7 @@ class BioinfoDoc:
             else:
                 self.post_delivery_info()
         self.resolution_info = self.rest_api.get_request(
-            request_info="service-data", safe=False, resolution=self.resolution_id
+            request_info="service-data", safe=True, resolution=self.resolution_id
         )
         self.services_requested = self.resolution_info["resolutions"][0][
             "available_services"

--- a/bu_isciii/bioinfo_doc.py
+++ b/bu_isciii/bioinfo_doc.py
@@ -211,21 +211,32 @@ class BioinfoDoc:
         if self.type == "delivery":
             service_list = {}
             for service_id_requested in self.service_ids_requested_list:
-                service_list[service_id_requested] = bu_isciii.service_json.ServiceJson().get_find(service_id_requested, "label")
+                service_list[
+                    service_id_requested
+                ] = bu_isciii.service_json.ServiceJson().get_find(
+                    service_id_requested, "label"
+                )
             self.all_services = service_list
 
     def load_versions(self):
         """Load and parse the versions.yml file."""
-        result = subprocess.run(f"find /data/bi/services_and_colaborations/*/*/{self.service_name} -name '*versions.yml'", stdout=subprocess.PIPE, text=True, shell=True)
+        result = subprocess.run(
+            f"find /data/bi/services_and_colaborations/*/*/{self.service_name} -name '*versions.yml'",
+            stdout=subprocess.PIPE,
+            text=True,
+            shell=True,
+        )
         versions_files = result.stdout.strip().split("\n")
         if versions_files == [""]:
-            stderr.print(f"[red] No versions.yml files found for the service {self.service_name}!")
+            stderr.print(
+                f"[red] No versions.yml files found for the service {self.service_name}!"
+            )
             return "No software versions data available for this service"
         else:
             versions_data = {}
             loaded_contents = []
             for versions_file in versions_files:
-                with open(versions_file, 'r') as f:
+                with open(versions_file, "r") as f:
                     content = yaml.safe_load(f)
                 if content not in loaded_contents:
                     versions_data[versions_file] = content

--- a/bu_isciii/templates/jinja_template_delivery.j2
+++ b/bu_isciii/templates/jinja_template_delivery.j2
@@ -74,9 +74,8 @@ Here we describe information about the resolution delivery.
 {% endif %}
 
 {% if samples %}
-## Samples sequenced at iSCIII:
-
-Here we describe information about the project associated to the service:
+## Samples sequenced at ISCIII:
+##Here we describe information about the project associated to the service:
 {% if service_sequencing_center -%} * Sequencing center: {{ service_sequencing_center }}{% endif %}
 {% for run , projects in samples.items() %}
 * Run name: {{ run }}
@@ -86,6 +85,43 @@ Here we describe information about the project associated to the service:
         {% set comma = joiner(", ") %}{% for samples_in_project in samples_in_project %}{{ comma() }}{{ samples_in_project }}{% endfor %}
     {% endfor %}
 {% endfor %}
+{% endif %}
+
+<style>
+    .page-break { page-break-before: always; }
+</style>
+
+<div class="page-break"></div>
+
+## Software versions:
+
+{% if services_list is mapping and software_versions is mapping %}
+{%- set service_list = services_list.items() | list %}
+{%- set file_version_list = software_versions.items() | list %}
+
+{%- for index in range(service_list | length) %}
+  {%- if index < file_version_list | length %}
+    {%- set service_id, description = service_list[index] %}
+* <b>{{ description }} ({{ service_id }})</b>:
+    {%- set file_path, processes = file_version_list[index] %}
+    {%- if processes | length > 0 %}
+      {%- for process, tools in processes.items() %}
+    - {{ process }}:
+          {%- for tool, version in tools.items() %}
+        - {{ tool }}: {{ version }}
+          {%- endfor %}
+      {%- endfor %}
+    {%- else %}
+    - No software versions data available for this file path.
+    {%- endif %}
+  {%- else %}
+    {%- set service_id, description = service_list[index] %}
+* <b>{{ description }} ({{ service_id }})</b>:
+    - No software versions data available for this service.
+  {%- endif %}
+{%- endfor %}
+{% else %}
+No software versions data available for this service.
 {% endif %}
 
 <!---

--- a/bu_isciii/templates/services.json
+++ b/bu_isciii/templates/services.json
@@ -1,6 +1,6 @@
 {
     "assembly_annotation": {
-        "label": "",
+        "label": "Bacteria: De novo genome assembly and annotation",
         "template": "assembly",
         "url": "https://github.com/nf-core/bacass/tree/2.3.1",
         "order": 1,
@@ -17,7 +17,7 @@
         "results_md": "assets/reports/results/assembly.md"
     },
     "mtbseq": {
-        "label": "",
+        "label": "Bacteria: In-depth analysis of Mycobacterium species genomes (e.g. M. tuberculosis. M. bovis)",
         "template": "mtbseq",
         "order": 1,
         "begin": "base",
@@ -34,7 +34,7 @@
         "results_md": ""
     },
     "pikavirus": {
-      "label": "",
+      "label": "Viral: Detection and characterization of viral genomes within metagenomic data",
       "template": "pikavirus",
       "order": 1,
       "begin": "base",
@@ -51,7 +51,7 @@
       "results_md": "assets/reports/results/pikavirus.md"
   },
     "plasmidid_assembly": {
-      "label": "",
+      "label": "Bacteria: Plasmid analysis and characterization",
       "template": "plasmidid",
       "order": 1,
       "begin": "base",
@@ -85,7 +85,7 @@
         "results_md": ""
     },
     "wgmlst_chewbbaca": {
-        "label": "",
+        "label": "Bacteria: Core genome or whole genome Multi-Locus Sequence Typing analysis (cg/wgMLST)",
         "template": "chewbbaca",
         "order": 1,
         "begin": "base",
@@ -103,7 +103,7 @@
         "results_md": "assets/reports/results/wgmlst_chewbbaca.md"
     },
     "viralrecon": {
-        "label": "",
+        "label": "Viral: Genomic reconstruction, reference mapping and variant calling and/or de novo assembly",
         "template": "viralrecon",
         "url": "https://github.com/BU-ISCIII/viralrecon",
         "order": 1,
@@ -137,7 +137,7 @@
         "results_md": "assets/reports/results/rnaseq_deg.md"
     },
     "lowfreq_panel": {
-        "label": "",
+        "label": "Low-frequency variants detection and annotation for whole genome or sequencing panel (e.g. retinoblastoma gene panel)",
         "template": "lowfreq_panel",
         "url": "",
         "order": 1,
@@ -154,7 +154,7 @@
         "results_md": ""
     },
     "snippy": {
-      "label": "",
+      "label": "Fungal / bacteria / virus : Variant calling, annotation and SNP-based outbreak analysis (e.g. haploid fungal outbreak)",
       "template": "snippy",
       "order": 1,
       "begin": "base",
@@ -187,7 +187,7 @@
       "delivery_pdf": ""
     },
     "characterization": {
-      "label": "",
+      "label": "Bacteria: Multi-Locus Sequence Typing (MLST), analysis of virulence factors, antimicrobial resistance, and plasmids characterization",
       "template": "characterization",
       "url": "",
       "order": 1,
@@ -204,7 +204,7 @@
       "results_md": ""
     },
     "mag_met": {
-      "label": "",
+      "label": "Taxonomic based Identification and classification of organisms in complex communities",
       "template": "mag",
       "order": 2,
       "begin": "base",
@@ -221,7 +221,7 @@
       "results_md": "assets/reports/results/mag.md"
     },
     "exometrio": {
-      "label": "",
+      "label": "Human: Exome sequencing for variant calling, annotation and inheritance filtering (e.g. Exome sequencing of a human trio (two parents and one child))",
       "template": "exometrio",
       "url": "",
       "order": 1,
@@ -238,7 +238,7 @@
       "results_md": "assets/reports/results/trios.md"
     },
     "exomeeb": {
-      "label": "",
+      "label": "Eukaria: Variant calling and annotation for a sequencing panel (e.g. epidermolysis gene panel, mouse or rat gene panel)",
       "template": "exomeeb",
       "url": "",
       "order": 1,
@@ -255,7 +255,7 @@
       "results_md": "assets/reports/results/exomeeb.md"
     },
     "wgstrio": {
-      "label": "",
+      "label": "Human: Whole genome sequencing for SNPs variant calling, annotation and inheritance filtering (e.g.WGS of a human trio )",
       "template": "wgstrio",
       "url": "",
       "order": 1,
@@ -272,7 +272,7 @@
       "results_md": "assets/reports/results/trios.md"
     },
     "freebayes_outbreak": {
-      "label": "",
+      "label": "Eukaria (non-human): Variant calling, annotation and SNP-based outbreak analysis (e.g. diploid fungal outbreak)",
       "template": "freebayes_outbreak",
       "url": "",
       "order": 1,
@@ -289,7 +289,7 @@
       "results_md": ""
     },
     "IRMA": {
-      "label": "",
+      "label": "Viral Flu: Influenza fragment reconstruction and variant detection",
       "template": "IRMA",
       "url": "",
       "order": 1,
@@ -306,7 +306,7 @@
       "results_md": "assets/reports/results/irma_output.md"
     },
     "blast_nt": {
-      "label": "",
+      "label": "Alignment of de novo assembly contigs to database",
       "template": "blast_nt",
       "url": "",
       "order": 1,


### PR DESCRIPTION
<!--
# bu-isciii tools pull request

Based on nf-core/viralrecon pull request template

Fill in the appropriate checklist below and delete whatever is not relevant.

PRs should be made against the develop of hotfix branch, unless you're preparing a software release.
-->

## PR checklist

- [X] This comment contains a description of changes (with reason).
- [X] Make sure your code lints (`black and flake8`).
- If a new tamplate was added make sure:
    - [ ] Template's schema is added in `templates/services.json`.
    - [ ] Template's pipeline's documentation in `assets/reports/md/template.md` is added.
    - [ ] Results Documentation in `assets/reports/results/template.md` is updated.
- [X] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
- [ ] If you know a new user was added to the SFTP, make sure you added it to `templates/sftp_user.json`

## PR description

This PR addresses **#219**. 

**Explanation of the changes**:

**Three files** have been modified in this PR:

1. **`services.json`**: all labels corresponding to their respective pipelines have been included in `services.json`.
2. **`bioinfo_doc.py`**:
    * A new `load_versions(self)` function has been created, which looks for all `versions.yml` files associated to a certain service, extracts the absolute path of each one of these files and creates a dictionary, in which each path is associated to its content. This function also takes into consideration whether a versions.yml is identical to another one that has been already read, so that this info is not displayed in the .pdf file several times (this can be useful, for example, in the case of viralrecon, when we are dealing with various references or hosts).
    * Besides, this .py script has been modified so that all labels associated with a pipeline being used in a service are saved within a dictionary, so that this info is displayed in the delivery .pdf as a header.
3. **`jinja_template_delivery.j2`**:
    * A new software versions section has been added. First, this template checks whether the dictionaries containing the software versions and the labels with their respective pipelines are, indeed, dictionaries.
    * Then, it iterates over the services dictionary, so that a header is displayed in the delivery .pdf showing the label of the pipeline and its name. 
    * Then, for each header, this template checks whether there is versions information for the corresponding pipeline: if this is the case, all tools and their versions that were used in this pipeline are shown in the .pdf. Otherwise, a message indicating that no versions data are available is shown.
    * If no software data exists for the service in general, the same message is shown in general. This is also indicated when running `bu-isciii bioinfo-doc` in red.
