### PR TITLE
Added permissions fixing after running scratch-copy and implemented a new module

### DIFF
--- a/bu_isciii/__main__.py
+++ b/bu_isciii/__main__.py
@@ -649,5 +649,30 @@ def autoclean_sftp(ctx, sftp_folder, days):
     sftp_clean.handle_autoclean_sftp()
 
 
+# FIX PERMISSIONS
+@bu_isciii_cli.command(help_priority=9)
+@click.option(
+    "-d",
+    "--input_directory",
+    type=click.Path(),
+    default=None,
+    required=True,
+    help="Input directory to fix permissions (absolute path)",
+)
+@click.pass_context
+def fix_permissions(ctx, input_directory):
+    """
+    Fix permissions
+    """
+    if not os.path.isdir(input_directory):
+        exit("Invalid input directory")
+    conf = bu_isciii.config_json.ConfigJson()
+    permissions = conf.get_configuration("global").get("permissions")
+    bu_isciii.utils.remake_permissions(input_directory, permissions)
+    stderr = rich.console.Console(
+        stderr=True, force_terminal=bu_isciii.utils.rich_force_colors()
+    )
+    stderr.print(f"[green]Correct permissions were applied to {input_directory}")
+
 if __name__ == "__main__":
     run_bu_isciii()

--- a/bu_isciii/conf/configuration.json
+++ b/bu_isciii/conf/configuration.json
@@ -2,7 +2,11 @@
     "global": {
         "data_path": "/data/bi",
         "archived_path": "/archived/bi",
-        "yaml_conf_path": "~/buisciii_config.yml"
+        "yaml_conf_path": "~/buisciii_config.yml",
+        "permissions": {
+        "directory_chmod": "775",
+        "file_chmod": "664"
+        }
     },
     "sftp_copy": {
         "protocol": "rsync",

--- a/bu_isciii/scratch.py
+++ b/bu_isciii/scratch.py
@@ -187,6 +187,12 @@ class Scratch:
                             sync_source_contents=False,
                         )
                         self.srun_command(self.srun_settings, rsync_command)
+
+                        # After successful rsync, apply correct permissions
+                        conf = bu_isciii.config_json.ConfigJson()
+                        permissions_config = conf.get_configuration("global").get("permissions")
+                        bu_isciii.utils.remake_permissions(self.full_path, permissions_config)
+
                         stderr.print(
                             "[green]Successfully copied the directory to %s"
                             % dest_folder,

--- a/bu_isciii/utils.py
+++ b/bu_isciii/utils.py
@@ -7,6 +7,7 @@ import json
 import os
 import tarfile
 import sys
+import subprocess
 
 import questionary
 import rich
@@ -495,3 +496,30 @@ def process_yaml_file(yaml_file):
 
 def validate_date(date_previous, date_posterior):
     return
+
+
+def remake_permissions(copied_folder_path, permissions_config):
+    """
+    Change permissions of all files and directories in a given absolute path.
+
+    Args:
+        copied_folder_path: The path to the folder that was copied
+        permissions_config: Dictionary containing permissions configuration (e.g., {'directory_chmod': '755', 'file_chmod': '664'})
+    """
+    for root, dirs, files in os.walk(copied_folder_path):
+        # Full paths for directories
+        dirpaths = [os.path.join(root, dir) for dir in dirs]
+
+        # Full paths for files
+        filepaths = [os.path.join(root, file) for file in files]
+
+        # Change permissions for directories
+        for dir_path in dirpaths:
+            if "directory_chmod" in permissions_config:
+                subprocess.run(f"chown -R $(whoami):bi {copied_folder_path}", shell=True, check=True)
+                subprocess.run(f"find {copied_folder_path} -type d -exec chmod {permissions_config['directory_chmod']} {{}} \;", shell=True, check=True)
+
+        # Change permissions for files
+        for file_path in filepaths:
+            if "file_chmod" in permissions_config:
+                subprocess.run(f"find {copied_folder_path} -type f -exec chmod {permissions_config['file_chmod']} {{}} \;", shell=True, check=True)


### PR DESCRIPTION
<!--
# bu-isciii tools pull request

Based on nf-core/viralrecon pull request template

Fill in the appropriate checklist below and delete whatever is not relevant.

PRs should be made against the develop of hotfix branch, unless you're preparing a software release.
-->

## PR checklist

- [X] This comment contains a description of changes (with reason).
- [X] Make sure your code lints (`black and flake8`).
- If a new tamplate was added make sure:
    - [ ] Template's schema is added in `templates/services.json`.
    - [ ] Template's pipeline's documentation in `assets/reports/md/template.md` is added.
    - [ ] Results Documentation in `assets/reports/results/template.md` is updated.
- [X] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
- [ ] If you know a new user was added to the SFTP, make sure you added it to `templates/sftp_user.json`

## PR description

**This PR addresses #212.**

With the changes implemented in this PR, we make sure that all folders and files copied from `scratch` to `services_and_collaborations` have the correct permissions. Furthermore, a `fix-permissions` module has been added to the tools so that, by providing the absolute path to a folder, all its subfolders and files have the appropriate permissions. This way, when necessary, this module can be ran so that new folders or files have the permissions they should have to avoid any issues.