### PR TITLE
Emmtyper characterization template - Fixed path to blast database and update  params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Credits
 
 Code contributions to the new version:
+- [Daniel Valle](https://github.com/Daniel-VM)
+
 
 ### Template fixes and updates
+- Fixed path to blast database and update Emmtyper params [#339](https://github.com/BU-ISCIII/buisciii-tools/pull/339)
 
 ### Modules
 

--- a/bu_isciii/templates/characterization/ANALYSIS/ANALYSIS01_CHARACTERIZATION/04-emmtyper/lablog
+++ b/bu_isciii/templates/characterization/ANALYSIS/ANALYSIS01_CHARACTERIZATION/04-emmtyper/lablog
@@ -53,7 +53,7 @@ cat <<EOF > _01_emmtyper.sbatch
 # create results folder
 mkdir -p 01-typing
 mkdir -p 01-typing/tmps
-blastdb_path=/data/bi/references/cdc_emm_blastdb
+blastdb_path=/data/bi/references/cdc_emm_blastdb/20240509
 
 # Run emmtyper
 singularity exec \\
@@ -63,9 +63,9 @@ singularity exec \\
     /data/bi/pipelines/singularity-images/singularity-emmtyper.0.2.0--py_0 emmtyper \\
     -w blast \\
     --keep \\
-    --blast_db "\${blastdb_path}/cdc_emm_database29042024" \\
-    --percent-identity 95 \\
-    --culling-limit 5 \\
+    --blast_db "\${blastdb_path}/cdc_emm_database" \\
+    --percent-identity 100 \\
+    --culling-limit 5 \
     --output 01-typing/results_emmtyper.out \\
     --output-format verbose \\
     ./fasta_inputs/*.fasta


### PR DESCRIPTION
<!--
# bu-isciii tools pull request

Based on nf-core/viralrecon pull request template

Fill in the appropriate checklist below and delete whatever is not relevant.

PRs should be made against the develop of hotfix branch, unless you're preparing a software release.
-->

## PR checklist

- [X] This comment contains a description of changes (with reason).
- [ ] Make sure your code lints (`black and flake8`).
- If a new tamplate was added make sure:
    - [ ] Template's schema is added in `templates/services.json`.
    - [ ] Template's pipeline's documentation in `assets/reports/md/template.md` is added.
    - [ ] Results Documentation in `assets/reports/results/template.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
- [ ] If you know a new user was added to the SFTP, make sure you added it to `templates/sftp_user.json`

## PR description

Minor fixes and updates of the characterization template: emmtyper section.
- Fixed path to database.
- updated emmtyper params.

