### PR TITLE
Fixed copy-sftp bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fixed minor mistakes in chewBBACA's template [#425](https://github.com/BU-ISCIII/buisciii-tools/pull/425).
 - Fixed some issues in outbreak services [#428](https://github.com/BU-ISCIII/buisciii-tools/pull/428)
 - Add micromamba activation comment to viralrecon template lablog and add total_N_count to sgene_metrics script[#432](https://github.com/BU-ISCIII/buisciii-tools/pull/432)
+- Added last_folder field to plasmidid_assembly service in services.json [#434](https://github.com/BU-ISCIII/buisciii-tools/pull/434)
 
 ### Modules
 

--- a/buisciii/templates/services.json
+++ b/buisciii/templates/services.json
@@ -63,6 +63,7 @@
         "files":["mapping/sample_name.sorted.bam", "kmer/database.msh"]
       },
       "no_copy": ["RAW", "TMP"],
+      "last_folder":"REFERENCES",
       "delivery_md": "assets/reports/md/plasmidid.md",
       "results_md": "assets/reports/results/plasmidid.md"
   },


### PR DESCRIPTION
Fixed copy sftp bug by adding last_folder field to plasmidid_assembly service in services.json.

Closes #429 

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] Make sure your code lints (`black and flake8`).
- If a new tamplate was added make sure:
    - [ ] Template's schema is added in `templates/services.json`.
    - [ ] Template's pipeline's documentation in `assets/reports/md/template.md` is added.
    - [ ] Results Documentation in `assets/reports/results/template.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
- [ ] If you know a new user was added to the SFTP, make sure you added it to `templates/sftp_user.json`
