### PR TITLE
Fixed bioinfo-doc resume function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fixed some issues in outbreak services [#428](https://github.com/BU-ISCIII/buisciii-tools/pull/428)
 - Add micromamba activation comment to viralrecon template lablog and add total_N_count to sgene_metrics script[#432](https://github.com/BU-ISCIII/buisciii-tools/pull/432)
 - Added last_folder field to plasmidid_assembly service in services.json [#434](https://github.com/BU-ISCIII/buisciii-tools/pull/434)
+- Fixed bioinfo-doc crashing after resuming [#435](https://github.com/BU-ISCIII/buisciii-tools/pull/435)
 
 ### Modules
 

--- a/buisciii/bioinfo_doc.py
+++ b/buisciii/bioinfo_doc.py
@@ -639,7 +639,7 @@ class BioinfoDoc:
         if buisciii.utils.prompt_yn_question(
             "Do you want to add some delivery notes to the e-mail?", dflt=False
         ):
-            if self.provided_txt:
+            if hasattr(self, "provided_txt") and self.provided_txt is not None:
                 if buisciii.utils.prompt_yn_question(
                     f"Do you want to use notes from {self.provided_txt}?", dflt=False
                 ):


### PR DESCRIPTION
When trying to overwrite delivery notes while running bioinfo-doc (or resuming after aborting), the script crashes because the attribute self.provided_text is not defined.
This bug has been fixed by adding a step to check if self.provided_text is defined.

Closes #215 

- [x] This comment contains a description of changes (with reason).
- [ ] Make sure your code lints (`black and flake8`).
- If a new tamplate was added make sure:
    - [ ] Template's schema is added in `templates/services.json`.
    - [ ] Template's pipeline's documentation in `assets/reports/md/template.md` is added.
    - [ ] Results Documentation in `assets/reports/results/template.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
- [ ] If you know a new user was added to the SFTP, make sure you added it to `templates/sftp_user.json`
