### PR TITLE
Solved `_08_create_quality_control_summary.sh` bug in viralrecon template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.7dev] - YYYY-MM-DD : https://github.com/BU-ISCIII/buisciii-tools/releases/tag/2.2.7dev
+
+### Credits
+
+- [Jaime Ozáez](https://github.com/jaimeozaezm)
+
+### Template fixes and updates
+
+- Fixed bug in 08_create_quality_control_summary.sh (viralrecon template) [#447] (https://github.com/BU-ISCIII/buisciii-tools/pull/447).
+
+### Modules
+
+#### Added enhancements
+
+#### Fixes
+
+#### Changed
+
+#### Removed
+
+### Requirements
+
+
 ## [2.2.6] - 2025-02-25 : https://github.com/BU-ISCIII/buisciii-tools/releases/tag/2.2.6
 
 ### Credits

--- a/buisciii/templates/viralrecon/ANALYSIS/lablog_viralrecon
+++ b/buisciii/templates/viralrecon/ANALYSIS/lablog_viralrecon
@@ -664,7 +664,7 @@ do
     printf 'echo "bash deduplicate_long_table.sh" > _06_deduplicate_long_table.sh\n\n' >> ${FOLDER_NAME}/lablog
     echo "# micromamba activate outbreakinfo" >> ${FOLDER_NAME}/lablog
     printf 'echo "bash sgene_metrics.sh" > _07_create_sgene_metrics.sh\n\n' >> ${FOLDER_NAME}/lablog
-    printf 'echo "srun --partition short_idx --chdir ${scratch_dir} --output logs/LDM.log --job-name LDM python3 ${scratch_dir}/get_percentage_LDM.py -other_lineages 0" > _08_create_quality_control_summary.sh\n\n' >> ${FOLDER_NAME}/lablog
+    printf 'echo "srun --partition short_idx --chdir ${scratch_dir} --output LDM.log --job-name LDM python3 ${scratch_dir}/get_percentage_LDM.py -other_lineages 0" > _08_create_quality_control_summary.sh\n\n' >> ${FOLDER_NAME}/lablog
 
     i=$((i+1))
 done

--- a/buisciii/templates/viralrecon/ANALYSIS/lablog_viralrecon
+++ b/buisciii/templates/viralrecon/ANALYSIS/lablog_viralrecon
@@ -662,7 +662,7 @@ do
     echo "#module load R/4.2.1" >> ${FOLDER_NAME}/lablog
     printf 'echo "Rscript create_assembly_stats.R" > _05_create_stats_assembly.sh\n\n' >> ${FOLDER_NAME}/lablog
     printf 'echo "bash deduplicate_long_table.sh" > _06_deduplicate_long_table.sh\n\n' >> ${FOLDER_NAME}/lablog
-    printf 'echo "# micromamba activate outbreakinfo"\n' >> ${FOLDER_NAME}/lablog
+    echo "# micromamba activate outbreakinfo" >> ${FOLDER_NAME}/lablog
     printf 'echo "bash sgene_metrics.sh" > _07_create_sgene_metrics.sh\n\n' >> ${FOLDER_NAME}/lablog
     printf 'echo "srun --partition short_idx --chdir ${scratch_dir} --output logs/LDM.log --job-name LDM python3 ${scratch_dir}/get_percentage_LDM.py -other_lineages 0" > _08_create_quality_control_summary.sh\n\n' >> ${FOLDER_NAME}/lablog
 


### PR DESCRIPTION
Fixed bug when running `_08_create_quality_control_summary.sh`.

Closes #446 

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] Make sure your code lints (`black and flake8`).
- If a new tamplate was added make sure:
    - [ ] Template's schema is added in `templates/services.json`.
    - [ ] Template's pipeline's documentation in `assets/reports/md/template.md` is added.
    - [ ] Results Documentation in `assets/reports/results/template.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
- [ ] If you know a new user was added to the SFTP, make sure you added it to `templates/sftp_user.json`
