### PR TITLE
Add `assets` for Updating Lineage-Defining Mutations from `outbreak-info`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Fixed bug in 08_create_quality_control_summary.sh (viralrecon template) [#447](https://github.com/BU-ISCIII/buisciii-tools/pull/447).
 - Updated `services.json` file in order to properly delete folders and files when running clean module [#451](https://github.com/BU-ISCIII/buisciii-tools/pull/451).
-- Fixed bug in 08_create_quality_control_summary.sh (viralrecon template) [#447] (https://github.com/BU-ISCIII/buisciii-tools/pull/447).
-- Updated `services.json` file in order to properly delete folders and files when running clean module [#451](https://github.com/BU-ISCIII/buisciii-tools/pull/451).
 - Add assets for Updating Lineage-Defining Mutations from outbreak-info [#452](https://github.com/BU-ISCIII/buisciii-tools/pull/452)
 
 ### Modules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Credits
 
 - [Jaime Ozáez](https://github.com/jaimeozaezm)
+- [Alejandro Bernabeu](https://github.com/Aberdur)
 
 ### Template fixes and updates
 
 - Fixed bug in 08_create_quality_control_summary.sh (viralrecon template) [#447](https://github.com/BU-ISCIII/buisciii-tools/pull/447).
 - Updated `services.json` file in order to properly delete folders and files when running clean module [#451](https://github.com/BU-ISCIII/buisciii-tools/pull/451).
+- Fixed bug in 08_create_quality_control_summary.sh (viralrecon template) [#447] (https://github.com/BU-ISCIII/buisciii-tools/pull/447).
+- Add assets for Updating Lineage-Defining Mutations from outbreak-info [#452](https://github.com/BU-ISCIII/buisciii-tools/pull/452)
 
 ### Modules
 
@@ -60,7 +63,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Changed taxprofiler lablog to skip kaiju, centrifuge and metaphlan [#439](https://github.com/BU-ISCIII/buisciii-tools/pull/439)
 - Conditional Copy of QC Scripts in lablog_viralrecon and Fixes in 99-stats (SNIPPY) & parse_ariba.py [#449](https://github.com/BU-ISCIII/buisciii-tools/pull/449)
 - Add generate_summary_outbreak.py to Complete Template with Outbreak Analysis Results [#450](https://github.com/BU-ISCIII/buisciii-tools/pull/450)
-- Add assets for Updating Lineage-Defining Mutations from outbreak-info [#452](https://github.com/BU-ISCIII/buisciii-tools/pull/452)
 
 ### Modules
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Changed taxprofiler lablog to skip kaiju, centrifuge and metaphlan [#439](https://github.com/BU-ISCIII/buisciii-tools/pull/439)
 - Conditional Copy of QC Scripts in lablog_viralrecon and Fixes in 99-stats (SNIPPY) & parse_ariba.py [#449](https://github.com/BU-ISCIII/buisciii-tools/pull/449)
 - Add generate_summary_outbreak.py to Complete Template with Outbreak Analysis Results [#450](https://github.com/BU-ISCIII/buisciii-tools/pull/450)
+- Add assets for Updating Lineage-Defining Mutations from outbreak-info [#452](https://github.com/BU-ISCIII/buisciii-tools/pull/452)
 
 ### Modules
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fixed bug in 08_create_quality_control_summary.sh (viralrecon template) [#447](https://github.com/BU-ISCIII/buisciii-tools/pull/447).
 - Updated `services.json` file in order to properly delete folders and files when running clean module [#451](https://github.com/BU-ISCIII/buisciii-tools/pull/451).
 - Fixed bug in 08_create_quality_control_summary.sh (viralrecon template) [#447] (https://github.com/BU-ISCIII/buisciii-tools/pull/447).
+- Updated `services.json` file in order to properly delete folders and files when running clean module [#451](https://github.com/BU-ISCIII/buisciii-tools/pull/451).
 - Add assets for Updating Lineage-Defining Mutations from outbreak-info [#452](https://github.com/BU-ISCIII/buisciii-tools/pull/452)
 
 ### Modules

--- a/buisciii/__init__.py
+++ b/buisciii/__init__.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
-""" Main buisciii package file.
-"""
+"""Main buisciii package file."""
 
 import pkg_resources
 

--- a/buisciii/assets/outbreakinfo/get_mutations_outbreak_info.R
+++ b/buisciii/assets/outbreakinfo/get_mutations_outbreak_info.R
@@ -1,0 +1,112 @@
+# .libPaths("/home/abernabeu/tests/test_RELECOV_20241017_RLV_20241015_PANEL01_icasas_C/20241017_ANALYSIS01_AMPLICONS_HUMAN/LDMutations/20241205_variants/R_library")
+
+library(outbreakinfo)
+library(optparse)
+library(readxl)
+library(writexl)
+library(openxlsx)
+library(crayon)
+library(purrr)
+library(dplyr)
+library(stringr)
+options(browser = "xdg-open")
+################################################
+################################################
+##       PARSE COMMAND-LINE PARAMETERS        ##
+################################################
+################################################
+
+source("/data/ucct/bi/references/outbreakinfo/setAuthToken.R")
+source("/data/ucct/bi/references/outbreakinfo/getAuthToken.R")
+
+manageAuthToken <- function() {
+    token <- getAuthToken()
+    if (is.null(token)) {
+        # If token is not found, request authentication
+        message(crayon::yellow("No token found. Authenticating the user..."))
+        outbreakinfo::authenticateUser()
+        token <- Sys.getenv("OUTBREAK_INFO_TOKEN")
+        if (nzchar(token)) {
+            setAuthToken(token)
+            message(crayon::green("Token authenticated and successfully saved."))
+        } else {
+            stop(crayon::red("Could not obtain token after authentication."))
+        }
+    } else {
+        message(crayon::green("Token successfully loaded from file."))
+    }
+    Sys.setenv("OUTBREAK_INFO_TOKEN" = token)
+}
+
+manageAuthToken()
+
+message(crayon::blue("Continuing the analysis after token authentication."))
+
+cat(cyan$bgRed$bold("########################\nStarting outbreakinfo pipeline\n###############################\n"))
+
+option_list <- list(
+  make_option(c("-l", "--lineage_list"             ), type="character" , default='./Lineages_Mutations.xlsx'   , metavar="path"   , help="Path to lineage list file"),
+  make_option(c("-o", "--output_folder"            ), type="character" , default=NULL                    , metavar="path"   , help="Path to output directory" )
+)
+
+opt_parser <- OptionParser(option_list=option_list)
+opt        <- parse_args(opt_parser)
+
+if (is.null(opt$lineage_list)){
+  print_help(opt_parser)
+  stop("Please provide a lineage list file", call.=FALSE)
+}
+
+if (is.null(opt$output_folder)){
+    print_help(opt_parser)
+    stop("Please provide a path to output directory", call.=FALSE)
+}
+
+cat("########################\nRunning analysis with the following params:\n###############################\n")
+cat("-Lineage list file: ") + cat(opt$lineage_list)+cat("\n")
+cat("-Output directory: ") + cat(opt$output_folder)+cat("\n")
+
+####LOAD DATA####
+lineages_of_interest <- read_excel(opt$lineage_list, sheet = 1, col_names = TRUE)
+colnames(lineages_of_interest) = c("Lineages")
+lineages_of_interest <- as.vector(lineages_of_interest$Lineages)
+
+
+getMutationsByLineage <- function(pangolin_lineage, frequency=0.75, logInfo=TRUE){
+
+  if(length(pangolin_lineage) > 1) {
+    # Set frequency to 0 and then filter after the fact.
+    df <- map_df(pangolin_lineage, function(lineage) getGenomicData(query_url="lineage-mutations", pangolin_lineage = lineage, frequency = 0.75, logInfo = logInfo))
+
+    if(!is.null(df) && nrow(df) != 0){
+      mutations = df %>%
+        filter(prevalence >= frequency) %>%
+        pull(mutation) %>%
+        unique()
+
+      df <- df %>%
+        filter(mutation %in% mutations)
+    }
+
+  } else {
+    df <- getGenomicData(query_url="lineage-mutations", pangolin_lineage = pangolin_lineage, frequency = frequency, logInfo = logInfo)
+  }
+
+  return(df)
+}
+
+##GET LINEAGES DATA###
+mutations = getMutationsByLineage(pangolin_lineage=lineages_of_interest, frequency=0.75, logInfo = TRUE)
+table_name = paste(str_remove_all(as.Date(Sys.Date(), format = "%Y%m%d"), "-"), "mutaciones_definitorias_linaje.csv", sep = "_")
+table_path = paste(opt$output_folder, table_name, sep = "/")
+#write_xlsx(mutations, table_path, format_headers = F)
+write.csv(mutations, table_path, row.names = FALSE)
+
+####Find if missing mutations###
+missing <- setdiff(lineages_of_interest,unique(mutations$lineage))
+if (length(missing) > 0) {
+  cat("There are some missing lineages in the table: ") + cat(missing, sep = ", ")+cat("\n")
+}
+
+cat("Excel of defining mutations generated as:", table_name)
+save.image()

--- a/buisciii/assets/outbreakinfo/get_mutations_outbreak_info.R
+++ b/buisciii/assets/outbreakinfo/get_mutations_outbreak_info.R
@@ -1,5 +1,3 @@
-# .libPaths("/home/abernabeu/tests/test_RELECOV_20241017_RLV_20241015_PANEL01_icasas_C/20241017_ANALYSIS01_AMPLICONS_HUMAN/LDMutations/20241205_variants/R_library")
-
 library(outbreakinfo)
 library(optparse)
 library(readxl)

--- a/buisciii/assets/outbreakinfo/lablog
+++ b/buisciii/assets/outbreakinfo/lablog
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+scratch_dir=$(echo $PWD)
+
+# micromamba activate outbreakinfo
+
+echo "python3 update_lineage_data.py" > _00_update_lineage_data.sh
+
+echo "Rscript get_mutations_outbreak_info.R --lineage_list ./lineages_data/latest.xlsx --output_folder /data/ucct/bi/references/outbreakinfo" > _01_get_mutations_outbreakinfo.sh
+echo "srun --partition short_idx --time 2:00:00 --chdir ${scratch_dir} --output logs/GETLDM.log --job-name GETLDM bash ./_01_get_mutations_outbreakinfo.sh &" > _01_run_get_mutations_outbreakinfo.sh
+
+cat <<EOF > _02_version_mutations.sh
+#!/bin/bash
+
+BASE_DIR="lineages_data"
+DATE=$(date +%Y%m%d)  # Format YYYYMMDD
+OUTPUT_CSV="${DATE}_defining_lineage_mutations.csv"
+
+# Get the current Pango-Designation version from latest.csv
+LATEST_VERSION=$(readlink -f "$BASE_DIR/latest.csv" | awk -F'/' '{print $(NF-1)}')
+VERSION_DIR="$BASE_DIR/$LATEST_VERSION"
+
+# Verify that the mutation file exists in the current directory
+if [[ -f "$OUTPUT_CSV" ]]; then
+    echo "✅ Mutation file found: $OUTPUT_CSV"
+
+    ABSOLUTE_CSV_PATH="$(readlink -f "$OUTPUT_CSV")"
+
+    # Move the file to the version directory
+    mv "$ABSOLUTE_CSV_PATH" "$VERSION_DIR/"
+    echo "📂 File moved to: $VERSION_DIR/$OUTPUT_CSV"
+
+    # Create or update the symbolic link to the latest CSV file
+    ln -sf "$VERSION_DIR/$OUTPUT_CSV" "$BASE_DIR/latest_mutations.csv"
+    echo "🔗 Symbolic link updated: $BASE_DIR/latest_mutations.csv -> $VERSION_DIR/$OUTPUT_CSV"
+
+else
+    echo "❌ ERROR: Mutation file ($OUTPUT_CSV) not found. Make sure to run _01_ first."
+    exit 1
+fi
+
+EOF

--- a/buisciii/assets/outbreakinfo/update_lineage_data.py
+++ b/buisciii/assets/outbreakinfo/update_lineage_data.py
@@ -1,7 +1,6 @@
 import requests
 import os
 import pandas as pd
-from openpyxl import Workbook
 
 # URL Configuration
 TAGS_URL = "https://api.github.com/repos/cov-lineages/pango-designation/tags"

--- a/buisciii/assets/outbreakinfo/update_lineage_data.py
+++ b/buisciii/assets/outbreakinfo/update_lineage_data.py
@@ -8,6 +8,7 @@ TAGS_URL = "https://api.github.com/repos/cov-lineages/pango-designation/tags"
 CSV_URL = "https://raw.githubusercontent.com/cov-lineages/pango-designation/master/lineages.csv"
 BASE_DIR = "lineages_data"
 
+
 def get_latest_tag():
     """Fetches the latest published tag from the repository."""
     response = requests.get(TAGS_URL)
@@ -17,15 +18,18 @@ def get_latest_tag():
             return tags[0]["name"]  # Latest available tag
     raise Exception("Failed to fetch repository tags.")
 
+
 def clean_tag(tag):
     """Removes the leading 'v' if present to avoid duplicate names."""
     return tag.lstrip("v")
+
 
 def get_local_versions():
     """Lists locally stored versions in subdirectories."""
     if not os.path.exists(BASE_DIR):
         return []
     return [d for d in os.listdir(BASE_DIR) if os.path.isdir(os.path.join(BASE_DIR, d))]
+
 
 def download_new_version(tag):
     """Downloads the CSV file and stores it in a versioned subdirectory."""
@@ -62,6 +66,7 @@ def download_new_version(tag):
     else:
         print("❌ Error downloading the file.")
 
+
 def generate_excel(csv_path, excel_path, version):
     """Generates an Excel file with unique lineages from the CSV and includes the version."""
     try:
@@ -70,15 +75,17 @@ def generate_excel(csv_path, excel_path, version):
         df = pd.read_csv(csv_path, comment="#")  # Ignore version line
         print("📌 Detected columns in CSV:", df.columns)
 
-        if 'lineage' not in df.columns:
-            print("❌ ERROR: The 'lineage' column is missing in the CSV. Aborting Excel generation.")
+        if "lineage" not in df.columns:
+            print(
+                "❌ ERROR: The 'lineage' column is missing in the CSV. Aborting Excel generation."
+            )
             return
 
-        unique_lineages = df['lineage'].dropna().unique()
-        unique_df = pd.DataFrame(unique_lineages, columns=['Unique lineages'])
+        unique_lineages = df["lineage"].dropna().unique()
+        unique_df = pd.DataFrame(unique_lineages, columns=["Unique lineages"])
 
         # Create an Excel workbook with one sheet for lineages and another for the version
-        with pd.ExcelWriter(excel_path, engine='openpyxl') as writer:
+        with pd.ExcelWriter(excel_path, engine="openpyxl") as writer:
             unique_df.to_excel(writer, sheet_name="Lineages", index=False)
 
             # Add the version in a second sheet
@@ -91,16 +98,21 @@ def generate_excel(csv_path, excel_path, version):
     except Exception as e:
         print(f"❌ ERROR generating Excel file: {e}")
 
+
 def update_latest_symlinks(latest_csv_path, latest_excel_path):
     """Updates symbolic links 'latest.csv' and 'latest.xlsx'."""
     latest_csv_symlink = os.path.join(BASE_DIR, "latest.csv")
     latest_excel_symlink = os.path.join(BASE_DIR, "latest.xlsx")
 
-    for symlink, target in [(latest_csv_symlink, latest_csv_path), (latest_excel_symlink, latest_excel_path)]:
+    for symlink, target in [
+        (latest_csv_symlink, latest_csv_path),
+        (latest_excel_symlink, latest_excel_path),
+    ]:
         if os.path.exists(symlink) or os.path.islink(symlink):
             os.unlink(symlink)  # Remove old symbolic link
         os.symlink(os.path.abspath(target), symlink)  # Create new symbolic link
         print(f"🔗 Symbolic link '{symlink}' now points to {target}")
+
 
 if __name__ == "__main__":
     try:

--- a/buisciii/assets/outbreakinfo/update_lineage_data.py
+++ b/buisciii/assets/outbreakinfo/update_lineage_data.py
@@ -1,0 +1,110 @@
+import requests
+import os
+import pandas as pd
+from openpyxl import Workbook
+
+# URL Configuration
+TAGS_URL = "https://api.github.com/repos/cov-lineages/pango-designation/tags"
+CSV_URL = "https://raw.githubusercontent.com/cov-lineages/pango-designation/master/lineages.csv"
+BASE_DIR = "lineages_data"
+
+def get_latest_tag():
+    """Fetches the latest published tag from the repository."""
+    response = requests.get(TAGS_URL)
+    if response.status_code == 200:
+        tags = response.json()
+        if tags:
+            return tags[0]["name"]  # Latest available tag
+    raise Exception("Failed to fetch repository tags.")
+
+def clean_tag(tag):
+    """Removes the leading 'v' if present to avoid duplicate names."""
+    return tag.lstrip("v")
+
+def get_local_versions():
+    """Lists locally stored versions in subdirectories."""
+    if not os.path.exists(BASE_DIR):
+        return []
+    return [d for d in os.listdir(BASE_DIR) if os.path.isdir(os.path.join(BASE_DIR, d))]
+
+def download_new_version(tag):
+    """Downloads the CSV file and stores it in a versioned subdirectory."""
+    clean_version = clean_tag(tag)  # Clean the version to avoid "vv"
+    version_dir = os.path.join(BASE_DIR, f"v{clean_version}")  # Version folder
+    csv_path = os.path.join(version_dir, f"lineages_v{clean_version}.csv")
+    excel_path = os.path.join(version_dir, f"Lineages_Mutations_v{clean_version}.xlsx")
+
+    if clean_version in [clean_tag(v) for v in get_local_versions()]:
+        print(f"⚠️ The latest version is already stored in {csv_path}.")
+        update_latest_symlinks(csv_path, excel_path)
+        return
+
+    print(f"📥 Downloading new version to {csv_path}...")
+
+    os.makedirs(version_dir, exist_ok=True)  # Create directory if it doesn't exist
+
+    response = requests.get(CSV_URL)
+
+    if response.status_code == 200:
+        with open(csv_path, "w", encoding="utf-8") as f:
+            f.write(f"# Version: {tag}\n")  # Add version as the first line
+            f.write(response.text)  # Save CSV content
+        print(f"✅ File saved at {csv_path}.")
+
+        # 📌 🔥 Ensure Excel file is correctly generated 🔥 📌
+        if os.path.exists(csv_path):
+            print(f"📊 Generating Excel file: {excel_path} ...")
+            generate_excel(csv_path, excel_path, tag)
+        else:
+            print(f"❌ ERROR: CSV file not found at {csv_path}.")
+
+        update_latest_symlinks(csv_path, excel_path)
+    else:
+        print("❌ Error downloading the file.")
+
+def generate_excel(csv_path, excel_path, version):
+    """Generates an Excel file with unique lineages from the CSV and includes the version."""
+    try:
+        print(f"📂 Reading CSV: {csv_path}")
+
+        df = pd.read_csv(csv_path, comment="#")  # Ignore version line
+        print("📌 Detected columns in CSV:", df.columns)
+
+        if 'lineage' not in df.columns:
+            print("❌ ERROR: The 'lineage' column is missing in the CSV. Aborting Excel generation.")
+            return
+
+        unique_lineages = df['lineage'].dropna().unique()
+        unique_df = pd.DataFrame(unique_lineages, columns=['Unique lineages'])
+
+        # Create an Excel workbook with one sheet for lineages and another for the version
+        with pd.ExcelWriter(excel_path, engine='openpyxl') as writer:
+            unique_df.to_excel(writer, sheet_name="Lineages", index=False)
+
+            # Add the version in a second sheet
+            wb = writer.book
+            ws_version = wb.create_sheet(title="Metadata")
+            ws_version.append(["Version", version])
+
+            print(f"✅ Excel file generated at {excel_path} with version included.")
+
+    except Exception as e:
+        print(f"❌ ERROR generating Excel file: {e}")
+
+def update_latest_symlinks(latest_csv_path, latest_excel_path):
+    """Updates symbolic links 'latest.csv' and 'latest.xlsx'."""
+    latest_csv_symlink = os.path.join(BASE_DIR, "latest.csv")
+    latest_excel_symlink = os.path.join(BASE_DIR, "latest.xlsx")
+
+    for symlink, target in [(latest_csv_symlink, latest_csv_path), (latest_excel_symlink, latest_excel_path)]:
+        if os.path.exists(symlink) or os.path.islink(symlink):
+            os.unlink(symlink)  # Remove old symbolic link
+        os.symlink(os.path.abspath(target), symlink)  # Create new symbolic link
+        print(f"🔗 Symbolic link '{symlink}' now points to {target}")
+
+if __name__ == "__main__":
+    try:
+        latest_tag = get_latest_tag()
+        download_new_version(latest_tag)
+    except Exception as e:
+        print(f"❌ GENERAL ERROR: {e}")


### PR DESCRIPTION
<!--
# bu-isciii tools pull request

Based on nf-core/viralrecon pull request template

Fill in the appropriate checklist below and delete whatever is not relevant.

PRs should be made against the develop of hotfix branch, unless you're preparing a software release.
-->
## PR Description


This PR adds the necessary lablog and scripts to the assets directory for updating the list of lineage-defining mutations and managing its version control.

**Changes:**
- Uploaded lablog detailing the update process.
- Added scripts to automate the update of lineage-defining mutations.
- Implemented version control mechanisms to track changes over time.

## PR checklist

- [X] This comment contains a description of changes (with reason).
- [X] Make sure your code lints (`black and flake8`).
- If a new tamplate was added make sure:
    - [ ] Template's schema is added in `templates/services.json`.
    - [ ] Template's pipeline's documentation in `assets/reports/md/template.md` is added.
    - [ ] Results Documentation in `assets/reports/results/template.md` is updated.
- [X] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
- [ ] If you know a new user was added to the SFTP, make sure you added it to `templates/sftp_user.json`
