### PR TITLE
Fix `get_percentage_LDM.py` to Use Versioned CSV File

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fixed bug in 08_create_quality_control_summary.sh (viralrecon template) [#447](https://github.com/BU-ISCIII/buisciii-tools/pull/447).
 - Updated `services.json` file in order to properly delete folders and files when running clean module [#451](https://github.com/BU-ISCIII/buisciii-tools/pull/451).
 - Add assets for Updating Lineage-Defining Mutations from outbreak-info [#452](https://github.com/BU-ISCIII/buisciii-tools/pull/452)
+- Fix get_percentage_LDM.py to Use Versioned CSV File[#453](https://github.com/BU-ISCIII/buisciii-tools/pull/453).
 
 ### Modules
 

--- a/buisciii/templates/viralrecon/ANALYSIS/get_percentage_LDM.py
+++ b/buisciii/templates/viralrecon/ANALYSIS/get_percentage_LDM.py
@@ -15,7 +15,7 @@ input_directory_pattern = (
 )
 output_directory_pattern = "./*_viralrecon_mapping"
 lineage_csv_outbreak_pattern = (
-    "/data/ucct/bi/references/outbreakinfo/20250206_mutaciones_definitorias_linaje.csv"
+    "/data/ucct/bi/references/outbreakinfo/lineages_data/latest_mutations.csv"
 )
 
 # Locate directories and files matching the specified patterns


### PR DESCRIPTION
<!--
# bu-isciii tools pull request

Based on nf-core/viralrecon pull request template

Fill in the appropriate checklist below and delete whatever is not relevant.

PRs should be made against the develop of hotfix branch, unless you're preparing a software release.
-->
### PR Description:
This PR updates `get_percentage_LDM.py` to reference the latest version of the CSV file, which is updated whenever `pango-designation` assigns a new tag.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`black and flake8`).
- If a new tamplate was added make sure:
    - [ ] Template's schema is added in `templates/services.json`.
    - [ ] Template's pipeline's documentation in `assets/reports/md/template.md` is added.
    - [ ] Results Documentation in `assets/reports/results/template.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
- [ ] If you know a new user was added to the SFTP, make sure you added it to `templates/sftp_user.json`
