### PR TITLE
Removed single quotes from sftp_copy in configuration.json

### DIFF
--- a/buisciii/conf/configuration.json
+++ b/buisciii/conf/configuration.json
@@ -12,16 +12,16 @@
         "protocol": "rsync",
         "options": ["-rlpv", "--update", "-L", "--inplace"],
         "exclusions": [
-            "'*_NC'",
-            "'*lablog*'",
-            "'work'",
-            "'00-reads'",
-            "'*.sh'",
-            "'.nextflow*'",
-            "'*_DEL'",
-            "'*.R'",
-            "'*.py'",
-            "'*.sbatch'"
+            "*_NC",
+            "*lablog*",
+            "work",
+            "00-reads",
+            "*.sh",
+            ".nextflow*",
+            "*_DEL",
+            "*.R",
+            "*.py",
+            "*.sbatch"
         ]
     },
     "xtutatis_api_settings": {


### PR DESCRIPTION
<!--
# bu-isciii tools pull request

Based on nf-core/viralrecon pull request template

Fill in the appropriate checklist below and delete whatever is not relevant.

PRs should be made against the develop of hotfix branch, unless you're preparing a software release.
-->

## PR checklist

- [X] This comment contains a description of changes (with reason).
- [X] Make sure your code lints (`black and flake8`).
- If a new tamplate was added make sure:
    - [ ] Template's schema is added in `templates/services.json`.
    - [ ] Template's pipeline's documentation in `assets/reports/md/template.md` is added.
    - [ ] Results Documentation in `assets/reports/results/template.md` is updated.
- [X] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
- [ ] If you know a new user was added to the SFTP, make sure you added it to `templates/sftp_user.json`

## PR checklist

As per the title, this PR modifies configuration.json by removing single quotes from the sftp_copy field, which were preventing the sftp-copy module from working correctly. This PR closes #448.
