### PR TITLE
Some fixes and enhancements for lablog_viralrecon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Refactored `_02_pgzip.sh` to compress `.fastq` files and remove uncompressed versions [#455](https://github.com/BU-ISCIII/buisciii-tools/pull/455)
 - Created `_03_symlink.sh` to manage symbolic links in `ANALYSIS/00-reads/`, preventing broken links [#455](https://github.com/BU-ISCIII/buisciii-tools/pull/455)
 - Removed single quotes from sftp_copy in configuration.json [#458](https://github.com/BU-ISCIII/buisciii-tools/pull/458)
+- Fixed and enhanced some issues for lablog_viralrecon [#461](https://github.com/BU-ISCIII/buisciii-tools/pull/461)
 
 ### Modules
 

--- a/buisciii/templates/viralrecon/ANALYSIS/lablog_viralrecon
+++ b/buisciii/templates/viralrecon/ANALYSIS/lablog_viralrecon
@@ -290,7 +290,7 @@ check_references() {
     REF_FASTA=$(awk -v ref="$ref" '$0 ~ ref && /fasta/ {print $4}' /data/ucct/bi/references/refgenie/alias/references.txt)
     if [ -z "$REF_FASTA" ]; then
         log_message "File ${ref}.fasta is not yet downloaded."
-        obtain_family; if [ -z $family ]; then return; fi
+        obtain_family; if [ -z $family ]; then unset REF_GFF; return; fi
         # Loading SAMtools module
         module load SAMtools
         SAMtools_loaded=$(module list | grep -o 'SAMtools/[0-9.]\+-GCC-[0-9.]\+')

--- a/buisciii/templates/viralrecon/ANALYSIS/lablog_viralrecon
+++ b/buisciii/templates/viralrecon/ANALYSIS/lablog_viralrecon
@@ -367,6 +367,7 @@ check_references() {
                 log_message "$environment environment succesfully activated." green
             else
                 log_message "Refgenie environment is NOT ACTIVE. Exiting..." blk_red
+                exit 1
             fi
         fi
         if [ ! -e "/data/ucct/bi/references/refgenie/alias/${family}" ]; then # Check if directory doesn't exist

--- a/buisciii/templates/viralrecon/ANALYSIS/lablog_viralrecon
+++ b/buisciii/templates/viralrecon/ANALYSIS/lablog_viralrecon
@@ -321,7 +321,8 @@ check_references() {
                 refgenie build ${family}/fasta:${ref} --files fasta=/data/ucct/bi/references/refgenie/data/${digest}/fasta/${ref}/${ref}.fasta.gz -c /data/ucct/bi/references/refgenie/genome_config.yaml -R > ${ref}.fasta_build.log 2>&1
                 if grep -q "Created" "${ref}.fasta_build.log"; then
                     log_message "$(grep Created ${ref}.fasta_build.log) $(grep "/data/ucct/bi/references/refgenie/alias/" ${ref}.fasta_build.log)" bold
-                    bash /data/ucct/bi/references/refgenie/alias/ref.sh
+                    echo -e "${ref}\tfasta\t${family}\t/data/ucct/bi/references/refgenie/alias/${family}/fasta/${ref}/${family}.fa" >> /data/ucct/bi/references/refgenie/alias/references.txt
+                    #bash /data/ucct/bi/references/refgenie/alias/ref.sh (this scritp should be run periodically)
                     REF_FASTA=$(awk -v ref="$ref" '$0 ~ ref && /fasta/ {print $4}' /data/ucct/bi/references/refgenie/alias/references.txt)
                 else
                     log_message "An error ocurred during building asset for ${ref}.fasta file." blk_red
@@ -341,7 +342,7 @@ check_references() {
                 refgenie build ${family}/fasta:${ref} --files fasta=/data/ucct/bi/references/refgenie/data/${digest}/fasta/${ref}/${ref}.fasta.gz -c /data/ucct/bi/references/refgenie/genome_config.yaml -R > ${ref}.fasta_build.log 2>&1
                 if grep -q "Created" "${ref}.fasta_build.log"; then
                     log_message "$(grep Created ${ref}.fasta_build.log) $(grep "/data/ucct/bi/references/refgenie/alias/" ${ref}.fasta_build.log)" bold
-                    bash /data/ucct/bi/references/refgenie/alias/ref.sh
+                    echo -e "${ref}\tfasta\t${family}\t/data/ucct/bi/references/refgenie/alias/${family}/fasta/${ref}/${family}.fa" >> /data/ucct/bi/references/refgenie/alias/references.txt
                     REF_FASTA=$(awk -v ref="$ref" '$0 ~ ref && /fasta/ {print $4}' /data/ucct/bi/references/refgenie/alias/references.txt)
                 else
                     log_message "An error ocurred during building asset for ${ref}.fasta file." blk_red
@@ -382,7 +383,7 @@ check_references() {
                 refgenie add ${family}/gff:${ref} --path data/${digest}/ensembl_rb/${ref}/ --seek-keys '{"gff" : "'"${family}.gff"'"}' -c /data/ucct/bi/references/refgenie/genome_config.yaml > ${ref}.gff_add.log 2>&1
                 if grep -q "Created" "${ref}.gff_add.log"; then
                     log_message "$(grep Created ${ref}.gff_add.log) $(grep "/data/ucct/bi/references/refgenie/alias/" ${ref}.gff_add.log)" bold
-                    bash /data/ucct/bi/references/refgenie/alias/ref.sh
+                    echo -e "${ref}\tgff\t${family}\t/data/ucct/bi/references/refgenie/alias/${family}/gff/${ref}/${family}.gff" >> /data/ucct/bi/references/refgenie/alias/references.txt
                     REF_GFF=$(awk -v ref="$ref" '$0 ~ ref && /gff/ {print $4}' /data/ucct/bi/references/refgenie/alias/references.txt)
                 else
                     log_message "An error ocurred during adding asset for ${ref}.gff file." blk_red
@@ -401,7 +402,7 @@ check_references() {
                 refgenie add ${family}/gff:${ref} --path data/${digest}/ensembl_rb/${ref}/ --seek-keys '{"gff" : "'"${family}.gff"'"}' -c /data/ucct/bi/references/refgenie/genome_config.yaml > ${ref}.gff_add.log 2>&1
                 if grep -q "Created" "${ref}.gff_add.log"; then
                     log_message "$(grep Created ${ref}.gff_add.log) $(grep "/data/ucct/bi/references/refgenie/alias/" ${ref}.gff_add.log)" bold
-                    bash /data/ucct/bi/references/refgenie/alias/ref.sh
+                    echo -e "${ref}\tgff\t${family}\t/data/ucct/bi/references/refgenie/alias/${family}/gff/${ref}/${family}.gff" >> /data/ucct/bi/references/refgenie/alias/references.txt
                     REF_GFF=$(awk -v ref="$ref" '$0 ~ ref && /gff/ {print $4}' /data/ucct/bi/references/refgenie/alias/references.txt)
                 else
                     log_message "An error ocurred during adding asset for ${ref}.gff file." blk_red


### PR DESCRIPTION
- Modified the way lablog_viralrecon updates references.txt file in order to speed this process.
- Fixed wrong path to gff files when new references cannot be downloaded from ncbi.
- Added exiting stage when refgenie environment fails to load.

Closes #454 #456 #457 

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] Make sure your code lints (`black and flake8`).
- If a new tamplate was added make sure:
    - [ ] Template's schema is added in `templates/services.json`.
    - [ ] Template's pipeline's documentation in `assets/reports/md/template.md` is added.
    - [ ] Results Documentation in `assets/reports/results/template.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
- [ ] If you know a new user was added to the SFTP, make sure you added it to `templates/sftp_user.json`
