### PR TITLE
Update `get_percentage_LDM.py` to read `sample` column as string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Added _02_filter_results.sh script to pikavirus template [#466](https://github.com/BU-ISCIII/buisciii-tools/pull/466)
 - Changed short_obx for middle_idx in 02-clean.sh [#468](https://github.com/BU-ISCIII/buisciii-tools/pull/468)
 - Update exometrio lablog to Handle Fourth Individual [#469](https://github.com/BU-ISCIII/buisciii-tools/pull/469)
+- Update get_percentage_LDM.py to read sample column as string [#470](https://github.com/BU-ISCIII/buisciii-tools/pull/470)
 
 ### Modules
 

--- a/buisciii/templates/viralrecon/ANALYSIS/get_percentage_LDM.py
+++ b/buisciii/templates/viralrecon/ANALYSIS/get_percentage_LDM.py
@@ -182,7 +182,9 @@ def process_directory(input_directory, lineage_csv_outbreak, output_directory):
     print(f"Summary file saved: {summary_tsv}")
 
     try:
-        tsv_df = pd.read_csv("./s_gene_combined_metrics.tsv", sep="\t", dtype={"sample": str})
+        tsv_df = pd.read_csv(
+            "./s_gene_combined_metrics.tsv", sep="\t", dtype={"sample": str}
+        )
     except FileNotFoundError:
         raise FileNotFoundError(
             "TSV file 's_gene_combined_metrics.tsv' not found in the current directory."

--- a/buisciii/templates/viralrecon/ANALYSIS/get_percentage_LDM.py
+++ b/buisciii/templates/viralrecon/ANALYSIS/get_percentage_LDM.py
@@ -182,7 +182,7 @@ def process_directory(input_directory, lineage_csv_outbreak, output_directory):
     print(f"Summary file saved: {summary_tsv}")
 
     try:
-        tsv_df = pd.read_csv("./s_gene_combined_metrics.tsv", sep="\t")
+        tsv_df = pd.read_csv("./s_gene_combined_metrics.tsv", sep="\t", dtype={"sample": str})
     except FileNotFoundError:
         raise FileNotFoundError(
             "TSV file 's_gene_combined_metrics.tsv' not found in the current directory."


### PR DESCRIPTION
<!--
# bu-isciii tools pull request

Based on nf-core/viralrecon pull request template

Fill in the appropriate checklist below and delete whatever is not relevant.

PRs should be made against the develop of hotfix branch, unless you're preparing a software release.
-->
### PR Description

This change allows that when reading the `s_gene_combined_metrics.tsv` file the `sample` column is processed as a `string`.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`black and flake8`).
- If a new tamplate was added make sure:
    - [ ] Template's schema is added in `templates/services.json`.
    - [ ] Template's pipeline's documentation in `assets/reports/md/template.md` is added.
    - [ ] Results Documentation in `assets/reports/results/template.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
- [ ] If you know a new user was added to the SFTP, make sure you added it to `templates/sftp_user.json`
