### PR TITLE
Update `get_percentage_LDM.py` to Handle Cases with `No Lineage Found` in outbreak.info CSV

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Update exometrio lablog to Handle Fourth Individual [#469](https://github.com/BU-ISCIII/buisciii-tools/pull/469)
 - Update get_percentage_LDM.py to read sample column as string [#470](https://github.com/BU-ISCIII/buisciii-tools/pull/470)
 - Updated ivar varsion in viralrecon template to makwe it work with IonTorrent data [#471](https://github.com/BU-ISCIII/buisciii-tools/pull/471)
+-Update get_percentage_LDM.py to Handle Cases with No Lineage Found in outbreak.info CSV [#473](https://github.com/BU-ISCIII/buisciii-tools/pull/473)
 
 ### Modules
 

--- a/buisciii/templates/viralrecon/ANALYSIS/get_percentage_LDM.py
+++ b/buisciii/templates/viralrecon/ANALYSIS/get_percentage_LDM.py
@@ -166,12 +166,16 @@ def process_directory(input_directory, lineage_csv_outbreak, output_directory):
             input_file, lineage_csv_outbreak, output_tsv, sample_name
         )
         if lineage_df is not None:
-            valid_mutations = lineage_df[lineage_df["LDM"].isin([0, 1])]
-            detected_percentage = (
-                (valid_mutations["LDM"].sum() / len(valid_mutations)) * 100
-                if len(valid_mutations) > 0
-                else 0.0
-            )
+            has_ldm_info = (lineage_df["in_lineage"] == "Yes").any()
+            if not has_ldm_info:
+                detected_percentage = "Data Not Evaluable [NCIT:C186292]"
+            else:
+                valid_mutations = lineage_df[lineage_df["LDM"].isin([0, 1])]
+                detected_percentage = (
+                    (valid_mutations["LDM"].sum() / len(valid_mutations)) * 100
+                    if len(valid_mutations) > 0
+                    else 0.0
+                )
             summary_results.append(
                 {"sample": sample_name, "%LDMutations": detected_percentage}
             )


### PR DESCRIPTION
<!--
# bu-isciii tools pull request

Based on nf-core/viralrecon pull request template

Fill in the appropriate checklist below and delete whatever is not relevant.

PRs should be made against the develop of hotfix branch, unless you're preparing a software release.
-->
### PR Description:
This PR updates the `get_percentage_LDM.py` script to correctly handle cases where no lineage is found at the `outbreak.info` CSV level.

**Changes:**
- Added a check to detect when the lineage column is empty or missing in the input CSV.
- The script now assigns `"Not Evaluable [NCIT:C186292]"` to `%LDMutations` in these cases.
- Prevents crashes or misleading 0% values when no lineage is available for comparison.



## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`black and flake8`).
- If a new tamplate was added make sure:
    - [ ] Template's schema is added in `templates/services.json`.
    - [ ] Template's pipeline's documentation in `assets/reports/md/template.md` is added.
    - [ ] Results Documentation in `assets/reports/results/template.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
- [ ] If you know a new user was added to the SFTP, make sure you added it to `templates/sftp_user.json`
