### PR TITLE
Modified clean.py in order to properly delete exact matching-name folders and files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Updated ivar varsion in viralrecon template to makwe it work with IonTorrent data [#471](https://github.com/BU-ISCIII/buisciii-tools/pull/471)
 - Update get_percentage_LDM.py to Handle Cases with No Lineage Found in outbreak.info CSV [#473](https://github.com/BU-ISCIII/buisciii-tools/pull/473)
 - Added autorun.sh script for automation of multiple sbatch running in viralrecon pipeline [#474](https://github.com/BU-ISCIII/buisciii-tools/pull/474)
+- Modified clean.py in order to properly delete exact matching-name folders and files [#476](https://github.com/BU-ISCIII/buisciii-tools/pull/476)
 
 ### Modules
 

--- a/buisciii/clean.py
+++ b/buisciii/clean.py
@@ -6,6 +6,7 @@ import os
 import logging
 import shutil
 from rich.console import Console
+import pdb
 
 # Local imports
 import buisciii
@@ -220,12 +221,12 @@ class CleanUp:
         # I've tried to continue if found, but I guess there could be several work folders in the project.. Let's see how it goes
         for root, dirs, files in os.walk(self.full_path):
             for item_to_be_found in to_find:
-                if root.endswith(item_to_be_found):
+                if os.path.basename(root) == item_to_be_found:
                     pathlist.append(root)
                     found.append(item_to_be_found)
                 for file in files:
                     path = os.path.join(root, file)
-                    if path.endswith(item_to_be_found):
+                    if file == item_to_be_found:
                         pathlist.append(path)
                         found.append(item_to_be_found)
 

--- a/buisciii/clean.py
+++ b/buisciii/clean.py
@@ -6,7 +6,6 @@ import os
 import logging
 import shutil
 from rich.console import Console
-import pdb
 
 # Local imports
 import buisciii


### PR DESCRIPTION
Clean module has a bug when cleaning folders. Previously, when searching for folders to clean up, only the end of the folder name was matched ( the same applies to files), potentially leading to the unintentional deletion of folders and files.
For this reason, the way in which these folders and files are searched has been modified, making an exact match necessary to proceed with their cleaning.

Closes #462 

<!--
# bu-isciii tools pull request

Based on nf-core/viralrecon pull request template

Fill in the appropriate checklist below and delete whatever is not relevant.

PRs should be made against the develop of hotfix branch, unless you're preparing a software release.
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] Make sure your code lints (`black and flake8`).
- If a new tamplate was added make sure:
    - [ ] Template's schema is added in `templates/services.json`.
    - [ ] Template's pipeline's documentation in `assets/reports/md/template.md` is added.
    - [ ] Results Documentation in `assets/reports/results/template.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
- [ ] If you know a new user was added to the SFTP, make sure you added it to `templates/sftp_user.json`
