### PR TITLE
Added sed to lablog_bam2fq to allow proper creation of variable sample (i.e. EPI_ISL_111111)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - [Victor Lopez](https://github.com/victor5lm)
 - [Alejandro Bernabeu](https://github.com/Aberdur)
+- [Juan Ledesma](https://github.com/juanledesma78)
 
 ### Template fixes and updates
 
 - Updated create_summary_report.sh to properly handle single end reads [#509](https://github.com/BU-ISCIII/buisciii-tools/pull/509).
 - Fix relative path handling in snpeff/snpsift annotation [#509](https://github.com/BU-ISCIII/buisciii-tools/pull/509).
+- Added sed to lablog_bam2fq so that _R1.bam is removed and the variable sample is created properly for those sample ids having several underscores (i.e. EPI_ISL_666)[#490](https://github.com/BU-ISCIII/buisciii-tools/pull/490)
 
 ### Modules
 
@@ -50,6 +52,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Added flu_type to summary_stats (IRMA template) [#501](https://github.com/BU-ISCIII/buisciii-tools/pull/501).
 - Fixed errors in IRMA template and fixed errors in irma2vcf script [#500](https://github.com/BU-ISCIII/buisciii-tools/pull/500)
 - Modified artic bed version in lablog_viralrecon for SARS-CoV-2 analysis [#505](https://github.com/BU-ISCIII/buisciii-tools/pull/505)
+
 
 ### Modules
 

--- a/buisciii/templates/viralrecon/RAW/lablog_bam2fq
+++ b/buisciii/templates/viralrecon/RAW/lablog_bam2fq
@@ -11,7 +11,7 @@ fi
 
 find . -maxdepth 1 -type f -name "*.bam" | while read -r filepath; do
     filename=$(basename "$filepath")  
-    sample=$(echo "$filename" | cut -d '_' -f1)  
+    sample=$(echo "$filename"| sed -E 's/_R[12]\.bam//g')  
 
     output_log="logs/BAM2FQ.${sample}.%j.log"  
 


### PR DESCRIPTION
Cut has been replaced with sed in order to replace `_R1.bam` in the bam files and so allow the creation of the variable sample for those sample ids having several underscores such as GISAID records (i.e. EPI_ISL_666) when relecov-tools are used. 
Sed has been added rather than any other options becuase pipeline_manager.py from relecov-tools adds the last part of the file name to the sequencing_sample_id 

`seq_r1_sample_id = sample["sequencing_sample_id"] + "_R1." + ext`

and it should work porperly without deeply changing the code. 

<!--
# bu-isciii tools pull request

Based on nf-core/viralrecon pull request template

Fill in the appropriate checklist below and delete whatever is not relevant.

PRs should be made against the develop of hotfix branch, unless you're preparing a software release.
-->

## PR checklist

- [X] This comment contains a description of changes (with reason).
- [ ] Make sure your code lints (`black and flake8`).
- If a new template was added make sure:
    - [ ] Template's schema is added in `templates/services.json`.
    - [ ] Template's pipeline's documentation in `assets/reports/md/template.md` is added.
    - [ ] Results Documentation in `assets/reports/results/template.md` is updated.
- [X] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
- [ ] If you know a new user was added to the SFTP, make sure you added it to `templates/sftp_user.json`
