### PR TITLE
Added sort -u to wgs_metrics_all.txt file generation command in 99-stats lablog (snippy template)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [Alejandro Bernabeu](https://github.com/Aberdur)
 - [Sergio Olmos](https://github.com/OPSergio)
 - [Sara Monzon](https://github.com/saramonzon)
+- [Jaime Ozáez](https://github.com/jaimeozaez)
 
 ### Template fixes and updates
 
 - Updated snippy template, now using a modified version of snippy with different low coverage masking[#489](https://github.com/BU-ISCIII/buisciii-tools/pull/489)
 - Update PlasmidID Report Generation to Output Summary by Sample [#483](https://github.com/BU-ISCIII/buisciii-tools/pull/483)
 - Update of the execution of summary_report_pid.py in plasmidID lablog [#484](https://github.com/BU-ISCIII/buisciii-tools/pull/484)
+- Added `sort -u` to wgs_metrics_all.txt file generation command in 99-stats lablog (snippy template) [#494](https://github.com/BU-ISCIII/buisciii-tools/pull/494)
 
 ### Modules
 
@@ -39,7 +41,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Credits
 
-- [Jaime Ozáez](https://github.com/jaimeozaezm)
+- [Jaime Ozáez](https://github.com/jaimeozaez)
 - [Alejandro Bernabeu](https://github.com/Aberdur)
 - [Sergio Olmos](https://github.com/OPSergio)
 - [Victor Lopez](https://github.com/victor5lm)
@@ -92,7 +94,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [Alejandro Bernabeu](https://github.com/Aberdur)
 - [Sara Monzón](https://github.com/saramonzon)
 - [Victor Lopez](https://github.com/victor5lm)
-- [Jaime Ozáez](https://github.com/jaimeozaezm)
+- [Jaime Ozáez](https://github.com/jaimeozaez)
 
 ### Template fixes and updates
 

--- a/buisciii/templates/snippy/ANALYSIS/ANALYSIS01_SNIPPY/99-stats/lablog
+++ b/buisciii/templates/snippy/ANALYSIS/ANALYSIS01_SNIPPY/99-stats/lablog
@@ -9,7 +9,7 @@ cat ../samples_id.txt | xargs -I % echo "printf '%\t' %;singularity exec -B ${sc
 cat ../samples_id.txt | xargs -I @@ echo "srun --chdir $scratch_dir --output logs/PICARD_@@.%j.log --job-name picard_@@ --partition short_idx --time 2:00:00 singularity exec -B ${scratch_dir}/../../../ /data/ucct/bi/pipelines/singularity-images/picard:2.25.1--hdfd78af_1 picard CollectWgsMetrics -VALIDATION_STRINGENCY LENIENT -I ${scratch_dir}/../04-snippy/@@/snps.bam -O ${scratch_dir}/@@_collect_wgs_metrics.txt -R ${scratch_dir}/reference.fna &" > _00_wgsmetrics.sh
 
 echo "printf \"SAMPLENAME\t\$(grep \"GENOME_TERRITORY\" *collect_wgs_metrics.txt | cut -d\":\" -f2 | sed 's/ /_/g'| sort -u)\n\" > wgs_metrics_all.txt" > _01_gather_wgs_metrics.sh
-echo "cat ../samples_id.txt | xargs -I % echo \"printf '%s\t' %; head -n 8 %_collect_wgs_metrics.txt | grep '^[0-9]'\" | bash >> wgs_metrics_all.txt" >> _01_gather_wgs_metrics.sh
+echo "cat ../samples_id.txt | xargs -I % echo \"printf '%\t'; head -n 8 %_collect_wgs_metrics.txt | grep '^[0-9]'\" | bash >> wgs_metrics_all.txt" >> _01_gather_wgs_metrics.sh
 echo "cut -f 1,2,3,14,17 wgs_metrics_all.txt > wgs_metrics_all_filtered.txt" >> _01_gather_wgs_metrics.sh
 
 echo "printf 'SAMPLENAME\tMAPPING\n' > header; cat header mapping_stats.txt > tmp; rm header mapping_stats.txt; mv tmp mapping_stats.txt" > _02_generate_summary.sh

--- a/buisciii/templates/snippy/ANALYSIS/ANALYSIS01_SNIPPY/99-stats/lablog
+++ b/buisciii/templates/snippy/ANALYSIS/ANALYSIS01_SNIPPY/99-stats/lablog
@@ -9,7 +9,7 @@ cat ../samples_id.txt | xargs -I % echo "printf '%\t' %;singularity exec -B ${sc
 cat ../samples_id.txt | xargs -I @@ echo "srun --chdir $scratch_dir --output logs/PICARD_@@.%j.log --job-name picard_@@ --partition short_idx --time 2:00:00 singularity exec -B ${scratch_dir}/../../../ /data/ucct/bi/pipelines/singularity-images/picard:2.25.1--hdfd78af_1 picard CollectWgsMetrics -VALIDATION_STRINGENCY LENIENT -I ${scratch_dir}/../04-snippy/@@/snps.bam -O ${scratch_dir}/@@_collect_wgs_metrics.txt -R ${scratch_dir}/reference.fna &" > _00_wgsmetrics.sh
 
 echo "printf \"SAMPLENAME\t\$(grep \"GENOME_TERRITORY\" *collect_wgs_metrics.txt | cut -d\":\" -f2 | sed 's/ /_/g'| sort -u)\n\" > wgs_metrics_all.txt" > _01_gather_wgs_metrics.sh
-echo "cat ../samples_id.txt | xargs -I % echo \"printf '%\t'; head -n 8 %_collect_wgs_metrics.txt | grep '^[0-9]'\" | bash >> wgs_metrics_all.txt" >> _01_gather_wgs_metrics.sh
+echo "cat ../samples_id.txt | xargs -I % echo \"printf '%\t'; head -n 8 %_collect_wgs_metrics.txt | grep '^[0-9]'\" | bash | sort -u >> wgs_metrics_all.txt" >> _01_gather_wgs_metrics.sh
 echo "cut -f 1,2,3,14,17 wgs_metrics_all.txt > wgs_metrics_all_filtered.txt" >> _01_gather_wgs_metrics.sh
 
 echo "printf 'SAMPLENAME\tMAPPING\n' > header; cat header mapping_stats.txt > tmp; rm header mapping_stats.txt; mv tmp mapping_stats.txt" > _02_generate_summary.sh


### PR DESCRIPTION
As indicated in the title, added `sort -u` function to wgs_metrics_all.txt file generation command in 99-stats lablog in order to avoid inconsistencies in the order of the samples between the samples_id.txt file and the mapping_stats.txt file.

Closes #492 

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] Make sure your code lints (`black and flake8`).
- If a new tamplate was added make sure:
    - [ ] Template's schema is added in `templates/services.json`.
    - [ ] Template's pipeline's documentation in `assets/reports/md/template.md` is added.
    - [ ] Results Documentation in `assets/reports/results/template.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
- [ ] If you know a new user was added to the SFTP, make sure you added it to `templates/sftp_user.json`
