### PR TITLE
Modified artic bed version in lablog_viralrecon for SARS-CoV-2 analysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.9dev] - 2025-MM-DD : https://github.com/BU-ISCIII/buisciii-tools/releases/tag/2.2.8dev
+
+### Credits
+
+- [Jaime Ozáez](https://github.com/jaimeozaez)
+
+### Template fixes and updates
+
+- Modified artic bed version in lablog_viralrecon for SARS-CoV-2 analysis [#505](https://github.com/BU-ISCIII/buisciii-tools/pull/505)
+
+### Modules
+
+#### Added enhancements
+
+#### Fixes
+
+#### Changed
+
+#### Removed
+
+### Requirements
+
 ## [2.2.8] - 2025-04-29 : https://github.com/BU-ISCIII/buisciii-tools/releases/tag/2.2.8
 
 ### Credits

--- a/buisciii/templates/viralrecon/ANALYSIS/lablog_viralrecon
+++ b/buisciii/templates/viralrecon/ANALYSIS/lablog_viralrecon
@@ -579,7 +579,7 @@ else
         update_nextclade
         update_pangolin
 
-        echo "primer_bed: '/data/ucct/bi/references/refgenie/alias/coronaviridae/primer_schemes/NC_045512.2/artic_v4-1_ncov-2019-primer.scheme.bed'" >> $PARAMS_FILE
+        echo "primer_bed: '/data/ucct/bi/references/refgenie/alias/coronaviridae/primer_schemes/NC_045512.2/nCoV-2019.artic.V5-3-2.scheme.bed'" >> $PARAMS_FILE
 
     elif [ "$virus_tag" == "rsv" ]; then       
         # Update Nextclade


### PR DESCRIPTION
Version of ARTIC primers is outdated. Modified artic bed version in lablog_viralrecon for SARS-CoV-2 analysis.

Closes #504 

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] Make sure your code lints (`black and flake8`).
- If a new tamplate was added make sure:
    - [ ] Template's schema is added in `templates/services.json`.
    - [ ] Template's pipeline's documentation in `assets/reports/md/template.md` is added.
    - [ ] Results Documentation in `assets/reports/results/template.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
- [ ] If you know a new user was added to the SFTP, make sure you added it to `templates/sftp_user.json`
