### PR TITLE
Fix relative path handling in `snpeff/snpsift` annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Credits
 
 - [Victor Lopez](https://github.com/victor5lm)
+- [Alejandro Bernabeu](https://github.com/Aberdur)
 
 ### Template fixes and updates
 
 - Updated create_summary_report.sh to properly handle single end reads [#509](https://github.com/BU-ISCIII/buisciii-tools/pull/509).
+- Fix relative path handling in snpeff/snpsift annotation [#509](https://github.com/BU-ISCIII/buisciii-tools/pull/509).
 
 ### Modules
 

--- a/buisciii/templates/IRMA/ANALYSIS/ANALYSIS01_IRMA/06-variant-calling/lablog
+++ b/buisciii/templates/IRMA/ANALYSIS/ANALYSIS01_IRMA/06-variant-calling/lablog
@@ -94,12 +94,12 @@ cat ./sample_type_ref.txt | xargs -I {} echo "
   micromamba activate refgenie_v0.12.1
   dataDir=$(refgenie seek snpeff/flu_surveillance_db -c /data/ucct/bi/references/refgenie/genome_config.yaml)
   echo -e \"-----Annotating \$sample_id \${fragment} vcf file-----\"
-  singularity exec -B /data/ucct/bi /data/ucct/bi/pipelines/singularity-images/snpeff:5.2--hdfd78af_1.1 snpEff \
+  singularity exec -B /data/ucct/bi -B ${scratch_dir} /data/ucct/bi/pipelines/singularity-images/snpeff:5.2--hdfd78af_1.1 snpEff \
   -v \
   -dataDir "\$dataDir" \
   -c genome.config \
   "\$ref" \
-  vcf_files/\${sample_id}/\${sample_id}_\${fragment}.vcf > annotated_vcfs/\${sample_id}/\${sample_id}_\${fragment}.snpeff.vcf
+  ${scratch_dir}/vcf_files/\${sample_id}/\${sample_id}_\${fragment}.vcf > annotated_vcfs/\${sample_id}/\${sample_id}_\${fragment}.snpeff.vcf
   echo -e \"-----Finished annotating \$sample_id \${fragment} vcf file-----\"
 " > _03_snpeff.sh
 
@@ -115,11 +115,11 @@ cat ./sample_type_ref.txt | xargs -I {} echo "
   micromamba activate refgenie_v0.12.1
   dataDir=$(refgenie seek snpeff/flu_surveillance_db -c /data/ucct/bi/references/refgenie/genome_config.yaml)
   echo -e \"-----Extracting relevant fields for \$sample_id \${fragment} vcf file-----\"
-  singularity exec -B /data/ucct/bi /data/ucct/bi/pipelines/singularity-images/snpsift\:5.2--hdfd78af_0 SnpSift \
+  singularity exec -B /data/ucct/bi -B ${scratch_dir} /data/ucct/bi/pipelines/singularity-images/snpsift\:5.2--hdfd78af_0 SnpSift \
   extractFields \
   -s "," \
   -e "." \
-  annotated_vcfs/\${sample_id}/\${sample_id}_\${fragment}.snpeff.vcf \
+  ${scratch_dir}/annotated_vcfs/\${sample_id}/\${sample_id}_\${fragment}.snpeff.vcf \
   CHROM \
   POS \
   REF \


### PR DESCRIPTION
<!--
# bu-isciii tools pull request

Based on nf-core/viralrecon pull request template

Fill in the appropriate checklist below and delete whatever is not relevant.

PRs should be made against the develop of hotfix branch, unless you're preparing a software release.
-->
## PR Description
This PR fixes an issue in the `snpeff/snpsift` annotation step where VCF input files were not correctly resolved due to incorrect handling of relative paths.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`black and flake8`).
- If a new tamplate was added make sure:
    - [ ] Template's schema is added in `templates/services.json`.
    - [ ] Template's pipeline's documentation in `assets/reports/md/template.md` is added.
    - [ ] Results Documentation in `assets/reports/results/template.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
- [ ] If you know a new user was added to the SFTP, make sure you added it to `templates/sftp_user.json`
