### PR TITLE
Update `IRMA 99-stats lablog` to raise error if taxprofiler results are missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Updated create_summary_report.sh to properly handle single end reads [#509](https://github.com/BU-ISCIII/buisciii-tools/pull/509).
 - Fix relative path handling in snpeff/snpsift annotation [#509](https://github.com/BU-ISCIII/buisciii-tools/pull/509).
 - Added sed to lablog_bam2fq so that _R1.bam is removed and the variable sample is created properly for those sample ids having several underscores (i.e. EPI_ISL_666)[#490](https://github.com/BU-ISCIII/buisciii-tools/pull/490)
+- Update IRMA 99-stats lablog to request taxprofiler results before proceeding [#515](https://github.com/BU-ISCIII/buisciii-tools/pull/515).
 
 ### Modules
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Updated create_summary_report.sh to properly handle single end reads [#509](https://github.com/BU-ISCIII/buisciii-tools/pull/509).
 - Fix relative path handling in snpeff/snpsift annotation [#509](https://github.com/BU-ISCIII/buisciii-tools/pull/509).
 - Added sed to lablog_bam2fq so that _R1.bam is removed and the variable sample is created properly for those sample ids having several underscores (i.e. EPI_ISL_666)[#490](https://github.com/BU-ISCIII/buisciii-tools/pull/490)
-- Update IRMA 99-stats lablog to raise error if taxprofiler results are missing [#515](https://github.com/BU-ISCIII/buisciii-tools/pull/515).
+- Update IRMA 99-stats lablog to raise Error if taxprofiler results are missing [#515](https://github.com/BU-ISCIII/buisciii-tools/pull/515).
 
 ### Modules
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Updated create_summary_report.sh to properly handle single end reads [#509](https://github.com/BU-ISCIII/buisciii-tools/pull/509).
 - Fix relative path handling in snpeff/snpsift annotation [#509](https://github.com/BU-ISCIII/buisciii-tools/pull/509).
 - Added sed to lablog_bam2fq so that _R1.bam is removed and the variable sample is created properly for those sample ids having several underscores (i.e. EPI_ISL_666)[#490](https://github.com/BU-ISCIII/buisciii-tools/pull/490)
-- Update IRMA 99-stats lablog to request taxprofiler results before proceeding [#515](https://github.com/BU-ISCIII/buisciii-tools/pull/515).
+- Update IRMA 99-stats lablog to raise error if taxprofiler results are missing [#515](https://github.com/BU-ISCIII/buisciii-tools/pull/515).
 
 ### Modules
 

--- a/buisciii/templates/IRMA/ANALYSIS/ANALYSIS01_IRMA/99-stats/lablog
+++ b/buisciii/templates/IRMA/ANALYSIS/ANALYSIS01_IRMA/99-stats/lablog
@@ -72,6 +72,20 @@ echo "
 
 # Create a table with relevant statistics.
 echo "
+  # Check if Taxprofiler results are available
+  echo \"Has Taxprofiler been executed and are the results available?\"
+  echo \"1) Yes\"
+  echo \"2) No\"
+  read -p \"Select an option [1/2]: \" answer
+
+  if [[ \"\$answer\" == \"2\" ]]; then
+    echo \"Please execute Taxprofiler before running this script.\"
+    exit 1
+  elif [[ \"\$answer\" != \"1\" ]]; then
+    echo \"Invalid option. Please run the script again and select 1 or 2.\"
+    exit 1
+  fi
+  
   # Activate the conda environment
   eval \"\$(micromamba shell hook --shell bash)\"
   micromamba activate refgenie_v0.12.1

--- a/buisciii/templates/IRMA/ANALYSIS/ANALYSIS01_IRMA/99-stats/lablog
+++ b/buisciii/templates/IRMA/ANALYSIS/ANALYSIS01_IRMA/99-stats/lablog
@@ -72,18 +72,12 @@ echo "
 
 # Create a table with relevant statistics.
 echo "
-  # Check if Taxprofiler results are available
-  echo \"Has Taxprofiler been executed and are the results available?\"
-  echo \"1) Yes\"
-  echo \"2) No\"
-  read -p \"Select an option [1/2]: \" answer
+  # Verify that Taxprofiler results exist before proceeding
+  TAXPROFILER_DIR=$(find ../../ -type d -name '*_TAXPROFILER' | head -n 1)
 
-  if [[ \"\$answer\" == \"2\" ]]; then
-    echo \"Please execute Taxprofiler before running this script.\"
-    exit 1
-  elif [[ \"\$answer\" != \"1\" ]]; then
-    echo \"Invalid option. Please run the script again and select 1 or 2.\"
-    exit 1
+  if [[ -z "$TAXPROFILER_DIR" ]] || ! compgen -G "$TAXPROFILER_DIR/kraken2/*/*.kraken2.report.txt" > /dev/null; then
+      echo "ERROR: Taxprofiler results not found. Please execute Taxprofiler before running this script."
+      exit 1
   fi
   
   # Activate the conda environment

--- a/buisciii/templates/IRMA/ANALYSIS/ANALYSIS01_IRMA/99-stats/lablog
+++ b/buisciii/templates/IRMA/ANALYSIS/ANALYSIS01_IRMA/99-stats/lablog
@@ -76,7 +76,7 @@ echo "
   TAXPROFILER_DIR=$(find ../../ -type d -name '*_TAXPROFILER' | head -n 1)
 
   if [[ -z "$TAXPROFILER_DIR" ]] || ! compgen -G "$TAXPROFILER_DIR/kraken2/*/*.kraken2.report.txt" > /dev/null; then
-      echo "ERROR: Taxprofiler results not found. Please execute Taxprofiler before running this script."
+      echo "ERROR: Taxprofiler results not found "(*.kraken2.report.txt)". Please execute Taxprofiler before running this script."
       exit 1
   fi
   

--- a/buisciii/templates/IRMA/ANALYSIS/ANALYSIS01_IRMA/99-stats/lablog
+++ b/buisciii/templates/IRMA/ANALYSIS/ANALYSIS01_IRMA/99-stats/lablog
@@ -72,7 +72,7 @@ echo "
 
 # Create a table with relevant statistics.
 echo "
-    # Verify that Taxprofiler results exist before proceeding
+  # Verify that Taxprofiler results exist before proceeding
   TAXPROFILER_DIR=\$(find ../../ -type d -name '*_TAXPROFILER' | head -n 1)
 
   if [[ -z \"\$TAXPROFILER_DIR\" ]] || ! compgen -G \"\$TAXPROFILER_DIR/kraken2/*/*.kraken2.report.txt\" > /dev/null; then

--- a/buisciii/templates/IRMA/ANALYSIS/ANALYSIS01_IRMA/99-stats/lablog
+++ b/buisciii/templates/IRMA/ANALYSIS/ANALYSIS01_IRMA/99-stats/lablog
@@ -72,11 +72,11 @@ echo "
 
 # Create a table with relevant statistics.
 echo "
-  # Verify that Taxprofiler results exist before proceeding
-  TAXPROFILER_DIR=$(find ../../ -type d -name '*_TAXPROFILER' | head -n 1)
+    # Verify that Taxprofiler results exist before proceeding
+  TAXPROFILER_DIR=\$(find ../../ -type d -name '*_TAXPROFILER' | head -n 1)
 
-  if [[ -z "$TAXPROFILER_DIR" ]] || ! compgen -G "$TAXPROFILER_DIR/kraken2/*/*.kraken2.report.txt" > /dev/null; then
-      echo "ERROR: Taxprofiler results not found "(*.kraken2.report.txt)". Please execute Taxprofiler before running this script."
+  if [[ -z \"\$TAXPROFILER_DIR\" ]] || ! compgen -G \"\$TAXPROFILER_DIR/kraken2/*/*.kraken2.report.txt\" > /dev/null; then
+      echo \"ERROR: Taxprofiler results not found in path: \$TAXPROFILER_DIR/kraken2/*/*.kraken2.report.txt. Please execute Taxprofiler before running this script.\"
       exit 1
   fi
   


### PR DESCRIPTION
<!--
# bu-isciii tools pull request

Based on nf-core/viralrecon pull request template

Fill in the appropriate checklist below and delete whatever is not relevant.

PRs should be made against the develop of hotfix branch, unless you're preparing a software release.
-->
## PR Description
This PR improves the robustness of the IRMA 99-stats lablog script by enforcing the presence of taxprofiler results before continuing with execution.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`black and flake8`).
- If a new tamplate was added make sure:
    - [ ] Template's schema is added in `templates/services.json`.
    - [ ] Template's pipeline's documentation in `assets/reports/md/template.md` is added.
    - [ ] Results Documentation in `assets/reports/results/template.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
- [ ] If you know a new user was added to the SFTP, make sure you added it to `templates/sftp_user.json`
