### PR TITLE
Fixed variable definition in 99-stats lablog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Added sed to lablog_bam2fq so that _R1.bam is removed and the variable sample is created properly for those sample ids having several underscores (i.e. EPI_ISL_666)[#490](https://github.com/BU-ISCIII/buisciii-tools/pull/490)
 - Update IRMA 99-stats lablog to raise Error if taxprofiler results are missing [#515](https://github.com/BU-ISCIII/buisciii-tools/pull/515).
 - Added a new lablog to create a .csv file for software versions in IRMA's template [#514](https://github.com/BU-ISCIII/buisciii-tools/pull/514/files).
+- Fixed wrong variable definition in IRMA's 99-stats lablog and added Nextclade's info into viralrecon's create_summary_report.sh script to be added into the mapping_illumina report [#518](https://github.com/BU-ISCIII/buisciii-tools/pull/518).
 
 ### Modules
 

--- a/buisciii/templates/IRMA/ANALYSIS/ANALYSIS01_IRMA/99-stats/lablog
+++ b/buisciii/templates/IRMA/ANALYSIS/ANALYSIS01_IRMA/99-stats/lablog
@@ -79,7 +79,7 @@ echo "
       echo \"ERROR: Taxprofiler results not found in path: \$TAXPROFILER_DIR/kraken2/*/*.kraken2.report.txt. Please execute Taxprofiler before running this script.\"
       exit 1
   fi
-  
+
   # Activate the conda environment
   eval \"\$(micromamba shell hook --shell bash)\"
   micromamba activate refgenie_v0.12.1
@@ -170,7 +170,7 @@ echo "
     number_unambiguous_bases=\$(awk -F \"\t\" -v id=\"\$in\" '\$1 == id {print \$2}' qc_metrics.tsv)
     number_Ns=\$(awk -F \"\t\" -v id=\"\$in\" '\$1 == id {print \$3}' qc_metrics.tsv)
     clade=\$(awk -F \";\" -v sample=\"\$(echo \$in | sed \"s/-/\\//g\")_HA\" '\$2 == sample {print \$3}' ../05-nextclade/nextclade_combined.csv)
-    clade_assignment_date=\$(cat ../05-nextclade/\${flu_type}*/nextclade.json | awk -F'\"' '/createdAt/ {print \$4}' | cut -d 'T' -f 1 | tr -d '-')
+    clade_assignment_date=\$(cat ../05-nextclade/\${flu_type}*/nextclade.json | awk -F'\"' '/createdAt/ {print \$4}' | cut -d 'T' -f 1 | tr -d '-' | head -n 1)
     clade_assignment_software_database_version=\$(cat ../05-nextclade/logs/NEXTCLADE_RUN_\${flu_type}_\$(echo \${flu_subtype} | cut -d \"N\" -f 1)_*.log | grep -oE '[0-9]{4}-[0-9]{2}-[0-9]{2}--[0-9]{2}-[0-9]{2}-[0-9]{2}Z' | head -n 1)
     cov_HA=\${gene_coverage[HA]}
     cov_MP=\${gene_coverage[MP]}


### PR DESCRIPTION
<!--
# bu-isciii tools pull request

Based on nf-core/viralrecon pull request template

Fill in the appropriate checklist below and delete whatever is not relevant.

PRs should be made against the develop of hotfix branch, unless you're preparing a software release.
-->

## PR checklist

- [X] This comment contains a description of changes (with reason).
- [X] Make sure your code lints (`black and flake8`).
- If a new tamplate was added make sure:
    - [ ] Template's schema is added in `templates/services.json`.
    - [ ] Template's pipeline's documentation in `assets/reports/md/template.md` is added.
    - [ ] Results Documentation in `assets/reports/results/template.md` is updated.
- [X] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
- [ ] If you know a new user was added to the SFTP, make sure you added it to `templates/sftp_user.json`

## PR description

* IRMA's 99-stats lablog file is updated to correct a wrong variable definition.
* Updated viralrecon's create_summary_report.sh to add clade's info into the mapping_illumina.tab file, apart from adding the lineage analysis date and the pango-data version into the pangolin .csv files.
