### PR TITLE
Fix `analysis_date` and `lineage_assignment_date` format in `create_summary_report.sh`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Credits
 
 - [Victor Lopez](https://github.com/victor5lm)
+- [Alejandro Bernabeu](https://github.com/Aberdur)
 
 ### Template fixes and updates
 
 - Redefinition of analysis_date and lineage_analysis_date based on mapping folder and DOC config in viralrecon's template [#523](https://github.com/BU-ISCIII/buisciii-tools/pull/523).
+- Fix analysis_date format in create_summary_report.sh [#525](https://github.com/BU-ISCIII/buisciii-tools/pull/525).
 
 ### Modules
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Template fixes and updates
 
 - Redefinition of analysis_date and lineage_analysis_date based on mapping folder and DOC config in viralrecon's template [#523](https://github.com/BU-ISCIII/buisciii-tools/pull/523).
-- Fix analysis_date format in create_summary_report.sh [#525](https://github.com/BU-ISCIII/buisciii-tools/pull/525).
+- Fix analysis_date and lineage_assignment_date format in create_summary_report.sh [#525](https://github.com/BU-ISCIII/buisciii-tools/pull/525).
 
 ### Modules
 

--- a/buisciii/templates/viralrecon/ANALYSIS/create_summary_report.sh
+++ b/buisciii/templates/viralrecon/ANALYSIS/create_summary_report.sh
@@ -57,7 +57,7 @@ do
     clade=$(tail -n +2 */variants/ivar/consensus/bcftools/nextclade/${arr[0]}.csv | cut -d ";" -f 3)
     clade_assignment_date=$analysis_date
     clade_assignment_software_database_version=$(cat *_viralrecon.log | grep 'nextclade_dataset_tag' | awk -F ': ' '{print $2}')
-    lineage_assignment_date=$(cat $(ls -t ../../DOC/*viralrecon.config | head -n 1) | grep -A1 "pangolin" | grep "datadir" | sed -E 's/.*\/([0-9]{8})\/.*/\1/')
+    lineage_assignment_date=$(cat $(ls -t ../../DOC/*viralrecon.config | head -n 1) | grep -A1 "pangolin" | grep "datadir" | sed -E 's/.*\/([0-9]{8})\/.*/\1/' | sed 's/\(....\)\(..\)\(..\)/\1-\2-\3/')
     lineage_assignment_database_version=$(cat /data/ucct/bi/references/pangolin/$lineage_assignment_date/*_pangolin.log | grep -oP 'pangolin-data updated to \K[^ ]+')
 
     # Update the .csv pangolin files 

--- a/buisciii/templates/viralrecon/ANALYSIS/create_summary_report.sh
+++ b/buisciii/templates/viralrecon/ANALYSIS/create_summary_report.sh
@@ -57,8 +57,9 @@ do
     clade=$(tail -n +2 */variants/ivar/consensus/bcftools/nextclade/${arr[0]}.csv | cut -d ";" -f 3)
     clade_assignment_date=$analysis_date
     clade_assignment_software_database_version=$(cat *_viralrecon.log | grep 'nextclade_dataset_tag' | awk -F ': ' '{print $2}')
-    lineage_assignment_date=$(cat $(ls -t ../../DOC/*viralrecon.config | head -n 1) | grep -A1 "pangolin" | grep "datadir" | sed -E 's/.*\/([0-9]{8})\/.*/\1/' | sed 's/\(....\)\(..\)\(..\)/\1-\2-\3/')
-    lineage_assignment_database_version=$(cat /data/ucct/bi/references/pangolin/$lineage_assignment_date/*_pangolin.log | grep -oP 'pangolin-data updated to \K[^ ]+')
+    lineage_assignment_date_raw=$(cat $(ls -t ../../DOC/*viralrecon.config | head -n 1) | grep -A1 "pangolin" | grep "datadir" | sed -E 's/.*\/([0-9]{8})\/.*/\1/')
+    lineage_assignment_date=$(echo $lineage_assignment_date_raw | sed 's/\(....\)\(..\)\(..\)/\1-\2-\3/')
+    lineage_assignment_database_version=$(cat /data/ucct/bi/references/pangolin/$lineage_assignment_date_raw/*_pangolin.log | grep -oP 'pangolin-data updated to \K[^ ]+')
 
     # Update the .csv pangolin files 
     temp_file="${arr[0]}_tmp.csv"

--- a/buisciii/templates/viralrecon/ANALYSIS/create_summary_report.sh
+++ b/buisciii/templates/viralrecon/ANALYSIS/create_summary_report.sh
@@ -52,7 +52,7 @@ do
 
     read_length=$(cat ${arr[1]}*/multiqc/multiqc_data/multiqc_fastqc.yaml | grep -A5 -E "'?${arr[0]}+(_1)?'?:$" | grep "Sequence length:" | tr "-" " " | rev | cut -d " " -f1 | rev)
 
-    analysis_date=$(ls -d *_mapping | grep -oP '\d{8}')
+    analysis_date=$(ls -d *_mapping | grep -oP '\d{8}' | sed 's/\(....\)\(..\)\(..\)/\1-\2-\3/')
 
     clade=$(tail -n +2 */variants/ivar/consensus/bcftools/nextclade/${arr[0]}.csv | cut -d ";" -f 3)
     clade_assignment_date=$analysis_date


### PR DESCRIPTION
<!--
# bu-isciii tools pull request

Based on nf-core/viralrecon pull request template

Fill in the appropriate checklist below and delete whatever is not relevant.

PRs should be made against the develop of hotfix branch, unless you're preparing a software release.
-->
### PR Description  

This PR updates the `create_summary_report.sh` script from the ViralRecon template to ensure that the `analysis_date` and `lineage_assignment_date` column is consistently generated using the ISO 8601 date format (`YYYY-MM-DD`).

**Changes Introduced:**
- Enforces the `analysis_date` and `lineage_assignment_date` to always follow the `YYYY-MM-DD` format, regardless of system locale or date utility defaults.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`black and flake8`).
- If a new tamplate was added make sure:
    - [ ] Template's schema is added in `templates/services.json`.
    - [ ] Template's pipeline's documentation in `assets/reports/md/template.md` is added.
    - [ ] Results Documentation in `assets/reports/results/template.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
- [ ] If you know a new user was added to the SFTP, make sure you added it to `templates/sftp_user.json`
