### PR TITLE
Included new script to download multiple SRA entries in fastq format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 #### Added enhancements
 
+- Added new script to download multiple SRA entries in fastq format when necessary [#551](https://github.com/BU-ISCIII/buisciii-tools/pull/551).
+
 #### Fixes
 
 #### Changed

--- a/buisciii/assets/utils/lablog_SRA_download
+++ b/buisciii/assets/utils/lablog_SRA_download
@@ -3,6 +3,6 @@ mkdir logs
 
 while IFS= read -r in || [ -n "$in" ]; do
     echo "srun --partition short_idx --mem 4G --cpus-per-task 2 --time 02:00:00 --job-name ${in}_SRA_DOWNLOAD --output logs/SRA_DOWNLOAD.${in}.%j.log fastq-dump --split-files --gzip ${in} &" >> _01_SRA_fastq_download.sh
-done < ../../ANALYSIS/samples_id.txt
+done < ../ANALYSIS/samples_id.txt
 
 echo 'for f in *_1.fastq.gz *_2.fastq.gz; do [ -e "$f" ] || continue; mv "$f" "$(echo "$f" | sed -E '\''s/_([12])\.fastq\.gz$/_R\1.fastq.gz/'\'')"; done' > _02_fix_filenames.sh

--- a/buisciii/assets/utils/lablog_SRA_download
+++ b/buisciii/assets/utils/lablog_SRA_download
@@ -1,3 +1,6 @@
+# This script is supposed to be run when having to download .fastq files from multiple SRA entries.
+# To run this script, please copy it to the corresponding RAW folder from the service.
+
 #module load SRA-Toolkit/3.0.5-gompi-2021a
 mkdir logs
 

--- a/buisciii/assets/utils/lablog_SRA_download
+++ b/buisciii/assets/utils/lablog_SRA_download
@@ -1,0 +1,8 @@
+#module load SRA-Toolkit/3.0.5-gompi-2021a
+mkdir logs
+
+while IFS= read -r in || [ -n "$in" ]; do
+    echo "srun --partition short_idx --mem 4G --cpus-per-task 2 --time 02:00:00 --job-name ${in}_SRA_DOWNLOAD --output logs/SRA_DOWNLOAD.${in}.%j.log fastq-dump --split-files --gzip ${in} &" >> _01_SRA_fastq_download.sh
+done < ../../ANALYSIS/samples_id.txt
+
+echo 'for f in *_1.fastq.gz *_2.fastq.gz; do [ -e "$f" ] || continue; mv "$f" "$(echo "$f" | sed -E '\''s/_([12])\.fastq\.gz$/_R\1.fastq.gz/'\'')"; done' > _02_fix_filenames.sh


### PR DESCRIPTION
<!--
# bu-isciii tools pull request

Based on nf-core/viralrecon pull request template

Fill in the appropriate checklist below and delete whatever is not relevant.

PRs should be made against the develop of hotfix branch, unless you're preparing a software release.
-->

## PR checklist

- [X] This comment contains a description of changes (with reason).
- [X] Make sure your code lints (`black and flake8`).
- If a new tamplate was added make sure:
    - [ ] Template's schema is added in `templates/services.json`.
    - [ ] Template's pipeline's documentation in `assets/reports/md/template.md` is added.
    - [ ] Results Documentation in `assets/reports/results/template.md` is updated.
- [X] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
- [ ] If you know a new user was added to the SFTP, make sure you added it to `templates/sftp_user.json`

## PR description

Sometimes, some assembly services that are requested to the Unit require downloading .fastq files from SRA, and this has to be done manually, which can be tedious when having to analyse multiple samples. This script automates this process, downloading the .fastq files for all the SRA entries indicated in samples_id.tx, and then renaming them so that they can be used properly for subsequent analyses.
