### PR TITLE
Updated create_summary_report.sh to handle negative values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fixed the way whether samples are paired or single-end is detected [#550](https://github.com/BU-ISCIII/buisciii-tools/pull/550).
 - Removed pseudo_aligner parameter from RNASeq's lablog and added all missing symlinks in its RESULTS's lablog [#552](https://github.com/BU-ISCIII/buisciii-tools/pull/552).
 - Updated scratch.py and __main__.py to properly handle custom paths and temporary directories [#555](https://github.com/BU-ISCIII/buisciii-tools/pull/555).
+- Updated create_summary_report.sh to transform negative values into 0 [#556](https://github.com/BU-ISCIII/buisciii-tools/pull/556).
 
 ### Modules
 

--- a/buisciii/templates/viralrecon/ANALYSIS/create_summary_report.sh
+++ b/buisciii/templates/viralrecon/ANALYSIS/create_summary_report.sh
@@ -34,8 +34,15 @@ do
 
     reads_virus=$(cat ${arr[1]}*/variants/bowtie2/samtools_stats/${arr[0]}.sorted.bam.flagstat | grep '+ 0 mapped' | cut -d ' ' -f1)
 
-    unmapped_reads=$(echo $((total_reads - (reads_host_x2+reads_virus))) )
-    perc_unmapped=$(echo $(awk -v v1=$total_reads -v v2=$unmapped_reads  'BEGIN {print (v2/v1)*100}') )
+    unmapped_reads=$((total_reads - (reads_host_x2 + reads_virus)))
+    if ((unmapped_reads < 0)); then
+        unmapped_reads=0
+    fi
+
+    perc_unmapped=$(awk -v v1=$total_reads -v v2=$unmapped_reads 'BEGIN {
+        if (v1 == 0 || v2 < 0) print 0;
+        else print (v2/v1)*100
+    }')
 
     ns_10x_perc=$(cat %Ns.tab | grep -w ${arr[0]} | grep ${arr[1]} | cut -f2)
 


### PR DESCRIPTION
<!--
# bu-isciii tools pull request

Based on nf-core/viralrecon pull request template

Fill in the appropriate checklist below and delete whatever is not relevant.

PRs should be made against the develop of hotfix branch, unless you're preparing a software release.
-->

## PR checklist

- [X] This comment contains a description of changes (with reason).
- [X] Make sure your code lints (`black and flake8`).
- If a new tamplate was added make sure:
    - [ ] Template's schema is added in `templates/services.json`.
    - [ ] Template's pipeline's documentation in `assets/reports/md/template.md` is added.
    - [ ] Results Documentation in `assets/reports/results/template.md` is updated.
- [X] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
- [ ] If you know a new user was added to the SFTP, make sure you added it to `templates/sftp_user.json`

## PR description

As per the title, this PR is done so that the `create_summary_report.sh` script from viralrecon's template transforms negative values to 0.


