### PR TITLE
Updated assembly stats script to properly handle when quast results are not available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Removed pseudo_aligner parameter from RNASeq's lablog and added all missing symlinks in its RESULTS's lablog [#552](https://github.com/BU-ISCIII/buisciii-tools/pull/552).
 - Updated scratch.py and __main__.py to properly handle custom paths and temporary directories [#555](https://github.com/BU-ISCIII/buisciii-tools/pull/555).
 - Updated create_summary_report.sh to transform negative values into 0 [#556](https://github.com/BU-ISCIII/buisciii-tools/pull/556).
+- Updated the assembly stats script to handle files in RAW properly and when quast results are not available for any sample [#557](https://github.com/BU-ISCIII/buisciii-tools/pull/557).
 
 ### Modules
 

--- a/buisciii/templates/viralrecon/ANALYSIS/create_assembly_stats.R
+++ b/buisciii/templates/viralrecon/ANALYSIS/create_assembly_stats.R
@@ -31,7 +31,7 @@ if (ncol(samples_ref) == 2) {
 
 # Fastq path
 
-fastq_names <- list.files("../../RAW/")
+fastq_names <- list.files("../../RAW/", pattern = "\\.fastq\\.gz$")
 path_run <- Sys.readlink(paste0("../../RAW/", fastq_names[1]))
 
 # columnas
@@ -78,31 +78,32 @@ for (i in 1:nrow(samples_ref)) {
     
     # Contigs
     assembly_workdir <- paste(workdir, "/assembly", sep = "")
-    quast_report_path <- paste("/",list.files(pattern = "transposed_report.tsv", recursive = TRUE, path = assembly_workdir), sep = "")
-    table_quast <- read.delim(paste0(assembly_workdir, quast_report_path), skip = 0, header = T, sep = "\t")
+    quast_report_path <- list.files(pattern = "transposed_report.tsv", recursive = TRUE, path = assembly_workdir)
+
+    if (length(quast_report_path) > 0) {
+        table_quast <- read.delim(paste0(assembly_workdir, "/", quast_report_path[1]), skip = 0, header = T, sep = "\t")
+    } else {
+        table_quast <- NULL
+    }
 
     # no quast error
-    if (exists("table_quast") == FALSE) {
+    if (is.null(table_quast)) {
         value_contigs <- NA
         value_lcontig <- NA
         value_genomef <- NA
     } else {
-
         sample_data <- subset(table_quast, Assembly == paste(name_id, "scaffolds", sep = "."))
         value_contigs <- as.numeric(sample_data$X..contigs)
         value_lcontig <- as.numeric(sample_data$Largest.contig)
         value_genomef <- as.numeric(as.character(sample_data$Genome.fraction....))
-        
-        # empty values
+
         # empty values
         if (length(value_contigs) == 0) {
             value_contigs <- NA
         }
-
         if (length(value_lcontig) == 0) {
             value_lcontig <- NA
         }
-
         if (length(value_genomef) == 0) {
             value_genomef <- NA
         }


### PR DESCRIPTION
<!--
# bu-isciii tools pull request

Based on nf-core/viralrecon pull request template

Fill in the appropriate checklist below and delete whatever is not relevant.

PRs should be made against the develop of hotfix branch, unless you're preparing a software release.
-->

## PR checklist

- [X] This comment contains a description of changes (with reason).
- [X] Make sure your code lints (`black and flake8`).
- If a new tamplate was added make sure:
    - [ ] Template's schema is added in `templates/services.json`.
    - [ ] Template's pipeline's documentation in `assets/reports/md/template.md` is added.
    - [ ] Results Documentation in `assets/reports/results/template.md` is updated.
- [X] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
- [ ] If you know a new user was added to the SFTP, make sure you added it to `templates/sftp_user.json`

## PR description

As per the title, this PR updates the assembly stats script to handle files in RAW properly and when quast results are not available for any sample.
