### PR TITLE
Fixed the bioinfo_doc module to properly ask for email text notes and the scratch module to use proper scratch_tmp_path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Fixed clean module to handle subpaths stated in services.json [#543](https://github.com/BU-ISCIII/buisciii-tools/pull/543).
 - Fixed bioinfo_doc module to be able to indicate type (service_info or delivery) via CLI [#558](https://github.com/BU-ISCIII/buisciii-tools/pull/558).
+- Fixed the bioinfo_doc module to properly ask for email text notes and the scratch module to use proper scratch_tmp_path [#559](https://github.com/BU-ISCIII/buisciii-tools/pull/559).
 
 #### Added enhancements
 

--- a/buisciii/bioinfo_doc.py
+++ b/buisciii/bioinfo_doc.py
@@ -51,11 +51,19 @@ class BioinfoDoc:
         conf=None,
         email_psswd=None,
     ):
+        # Type validation
+        valid_types = ["service_info", "delivery"]
         if type is None:
             self.type = buisciii.utils.prompt_selection(
                 msg="Select the documentation type you want to create",
-                choices=["service_info", "delivery"],
+                choices=valid_types,
             )
+        else:
+            if type not in valid_types:
+                raise ValueError(
+                    f"Invalid type: '{type}'. It must be one of the following: {', '.join(valid_types)}."
+                )
+            self.type = type
         self.conf = conf.get_configuration("bioinfo_doc")
         if path is None:
             if ask_path:

--- a/buisciii/bioinfo_doc.py
+++ b/buisciii/bioinfo_doc.py
@@ -678,9 +678,11 @@ class BioinfoDoc:
                             stderr.print(
                                 "No more attempts. Email notes will be given by prompt"
                             )
-                            email_data["email_notes"] = buisciii.utils.ask_for_some_text(
-                                msg="Write email notes"
-                            ).replace("\n", "<br />")
+                            email_data["email_notes"] = (
+                                buisciii.utils.ask_for_some_text(
+                                    msg="Write email notes"
+                                ).replace("\n", "<br />")
+                            )
                     else:
                         email_data["email_notes"] = buisciii.utils.ask_for_some_text(
                             msg="Write email notes"

--- a/buisciii/bioinfo_doc.py
+++ b/buisciii/bioinfo_doc.py
@@ -675,20 +675,10 @@ class BioinfoDoc:
                                 )
                                 break
                         else:
-                            stderr.print(
-                                "No more attempts. Email notes will be given by prompt"
-                            )
-                            email_data[
-                                "email_notes"
-                            ] = buisciii.utils.ask_for_some_text(
-                                msg="Write email notes"
-                            ).replace(
-                                "\n", "<br />"
-                            )
+                            stderr.print("No more attempts. Email notes will be given by prompt")
+                            email_data["email_notes"] = buisciii.utils.ask_for_some_text(msg="Write email notes").replace("\n", "<br />")
                     else:
-                        email_data["email_notes"] = buisciii.utils.ask_for_some_text(
-                            msg="Write email notes"
-                        ).replace("\n", "<br />")
+                        email_data["email_notes"] = buisciii.utils.ask_for_some_text(msg="Write email notes").replace("\n", "<br />")
             else:
                 if buisciii.utils.prompt_yn_question(
                     msg="Do you wish to provide a text file for email notes?",

--- a/buisciii/bioinfo_doc.py
+++ b/buisciii/bioinfo_doc.py
@@ -51,19 +51,11 @@ class BioinfoDoc:
         conf=None,
         email_psswd=None,
     ):
-        # Type validation
-        valid_types = ["service_info", "delivery"]
         if type is None:
             self.type = buisciii.utils.prompt_selection(
                 msg="Select the documentation type you want to create",
-                choices=valid_types,
+                choices=["service_info", "delivery"],
             )
-        else:
-            if type not in valid_types:
-                raise ValueError(
-                    f"Invalid type: '{type}'. It must be one of the following: {', '.join(valid_types)}."
-                )
-            self.type = type
         self.conf = conf.get_configuration("bioinfo_doc")
         if path is None:
             if ask_path:
@@ -655,9 +647,34 @@ class BioinfoDoc:
                         "\n", "<br />"
                     )
                 else:
-                    email_data["email_notes"] = buisciii.utils.ask_for_some_text(
-                        msg="Write email notes"
-                    ).replace("\n", "<br />")
+                    if buisciii.utils.prompt_yn_question(
+                        msg="Do you wish to provide a text file for email notes?",
+                        dflt=False,
+                    ):
+                        for i in range(3, -1, -1):
+                            email_data["email_notes"] = buisciii.utils.prompt_path(
+                                msg="Write the path to the file with RAW text as email notes"
+                            )
+                            if not os.path.isfile(
+                                os.path.expanduser(email_data["email_notes"])
+                            ):
+                                stderr.print(
+                                    f"Provided file doesn't exist. Attempts left: {i}"
+                                )
+                            else:
+                                stderr.print(f"File selected: {email_data['email_notes']}")
+                                break
+                        else:
+                            stderr.print(
+                                "No more attempts. Email notes will be given by prompt"
+                            )
+                            email_data["email_notes"] = buisciii.utils.ask_for_some_text(
+                                msg="Write email notes"
+                            ).replace("\n", "<br />")
+                    else:
+                        email_data["email_notes"] = buisciii.utils.ask_for_some_text(
+                            msg="Write email notes"
+                        ).replace("\n", "<br />")
             else:
                 if buisciii.utils.prompt_yn_question(
                     msg="Do you wish to provide a text file for email notes?",

--- a/buisciii/bioinfo_doc.py
+++ b/buisciii/bioinfo_doc.py
@@ -670,15 +670,21 @@ class BioinfoDoc:
                                     f"Provided file doesn't exist. Attempts left: {i}"
                                 )
                             else:
-                                stderr.print(f"File selected: {email_data['email_notes']}")
+                                stderr.print(
+                                    f"File selected: {email_data['email_notes']}"
+                                )
                                 break
                         else:
                             stderr.print(
                                 "No more attempts. Email notes will be given by prompt"
                             )
-                            email_data["email_notes"] = buisciii.utils.ask_for_some_text(
+                            email_data[
+                                "email_notes"
+                            ] = buisciii.utils.ask_for_some_text(
                                 msg="Write email notes"
-                            ).replace("\n", "<br />")
+                            ).replace(
+                                "\n", "<br />"
+                            )
                     else:
                         email_data["email_notes"] = buisciii.utils.ask_for_some_text(
                             msg="Write email notes"

--- a/buisciii/bioinfo_doc.py
+++ b/buisciii/bioinfo_doc.py
@@ -675,10 +675,16 @@ class BioinfoDoc:
                                 )
                                 break
                         else:
-                            stderr.print("No more attempts. Email notes will be given by prompt")
-                            email_data["email_notes"] = buisciii.utils.ask_for_some_text(msg="Write email notes").replace("\n", "<br />")
+                            stderr.print(
+                                "No more attempts. Email notes will be given by prompt"
+                            )
+                            email_data["email_notes"] = buisciii.utils.ask_for_some_text(
+                                msg="Write email notes"
+                            ).replace("\n", "<br />")
                     else:
-                        email_data["email_notes"] = buisciii.utils.ask_for_some_text(msg="Write email notes").replace("\n", "<br />")
+                        email_data["email_notes"] = buisciii.utils.ask_for_some_text(
+                            msg="Write email notes"
+                        ).replace("\n", "<br />")
             else:
                 if buisciii.utils.prompt_yn_question(
                     msg="Do you wish to provide a text file for email notes?",

--- a/buisciii/scratch.py
+++ b/buisciii/scratch.py
@@ -70,7 +70,9 @@ class Scratch:
             "resolution_full_number"
         ]
         if self.tmp_dir.startswith("/scratch/bi"):
-            tmp_dir = self.tmp_dir.replace("/scratch/bi", "/data/ucct/bi/scratch_tmp/bi", 1)
+            tmp_dir = self.tmp_dir.replace(
+                "/scratch/bi", "/data/ucct/bi/scratch_tmp/bi", 1
+            )
         else:
             tmp_dir = self.tmp_dir
         self.scratch_tmp_path = os.path.join(tmp_dir, self.service_folder)

--- a/buisciii/scratch.py
+++ b/buisciii/scratch.py
@@ -69,7 +69,11 @@ class Scratch:
         self.service_folder = self.resolution_info["resolutions"][0][
             "resolution_full_number"
         ]
-        self.scratch_tmp_path = os.path.join(self.tmp_dir, self.service_folder)
+        if self.tmp_dir.startswith("/scratch/bi"):
+            tmp_dir = self.tmp_dir.replace("/scratch/bi", "/data/ucct/bi/scratch_tmp/bi", 1)
+        else:
+            tmp_dir = self.tmp_dir
+        self.scratch_tmp_path = os.path.join(tmp_dir, self.service_folder)
         # params like --chdir, --partition and --time
         srun_params = self.conf["srun_settings"].items()
         self.srun_settings = [arg for param in srun_params for arg in param]


### PR DESCRIPTION
<!--
# bu-isciii tools pull request

Based on nf-core/viralrecon pull request template

Fill in the appropriate checklist below and delete whatever is not relevant.

PRs should be made against the develop of hotfix branch, unless you're preparing a software release.
-->

## PR checklist

- [X] This comment contains a description of changes (with reason).
- [X] Make sure your code lints (`black and flake8`).
- If a new tamplate was added make sure:
    - [ ] Template's schema is added in `templates/services.json`.
    - [ ] Template's pipeline's documentation in `assets/reports/md/template.md` is added.
    - [ ] Results Documentation in `assets/reports/results/template.md` is updated.
- [X] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
- [ ] If you know a new user was added to the SFTP, make sure you added it to `templates/sftp_user.json`

## PR description

This PR closes #547. Besides, the `scratch_tmp_dir` variable from scratch module is redefined so that data is copied properly to the corresponding route.
