### PR TITLE
Fixed `clean` and `bioinfo_doc` modules, as well as IRMA's 99-stats lablog

### DIFF
--- a/buisciii/__main__.py
+++ b/buisciii/__main__.py
@@ -419,10 +419,15 @@ def finish(ctx, resolution, path, ask_path, sftp_folder, tmp_dir):
     """
     Service cleaning, remove big files, rename folders before copy and copy resolution FOLDER to sftp.
     """
-    print("Starting cleaning scratch directory: " + tmp_dir)
+    
+    clean_tmp_dir = tmp_dir
+    if tmp_dir == "/scratch/bi/":
+        clean_tmp_dir = "/data/ucct/bi/scratch_tmp/bi"
+
+    print("Starting cleaning scratch directory: " + clean_tmp_dir)
     clean_scratch = buisciii.clean.CleanUp(
         resolution,
-        tmp_dir,
+        clean_tmp_dir,
         ask_path,
         "clean",
         ctx.obj["api_user"],

--- a/buisciii/bioinfo_doc.py
+++ b/buisciii/bioinfo_doc.py
@@ -256,7 +256,7 @@ class BioinfoDoc:
         if os.path.exists(self.service_folder):
             log.info("Already creted the service folder for %s", self.service_folder)
             stderr.print(
-                "[green] Skiping folder creation for service "
+                "[green] Skipping folder creation for service "
                 + self.service_folder
                 + ". Trying with subfolders"
             )
@@ -267,7 +267,7 @@ class BioinfoDoc:
                         self.service_folder,
                     )
                     stderr.print(
-                        "[green] Skiping folder creation for service "
+                        "[green] Skipping folder creation for service "
                         + self.service_folder
                         + "/"
                         + folder
@@ -547,7 +547,7 @@ class BioinfoDoc:
             "images",
         )
         if not os.path.exists(file_path):
-            stderr.print("[green] Coping images folder temporarylly to " + file_path)
+            stderr.print("[green] Copying images folder temporarily to " + file_path)
             images_folder = os.path.join(
                 os.path.dirname(os.path.realpath(__file__)), "assets/reports/md/images"
             )
@@ -678,11 +678,13 @@ class BioinfoDoc:
                             stderr.print(
                                 "No more attempts. Email notes will be given by prompt"
                             )
-                            email_data["email_notes"] = (
-                                buisciii.utils.ask_for_some_text(
-                                    msg="Write email notes"
-                                ).replace("\n", "<br />")
-                            )
+                            email_data["email_notes"] = None
+                    else:
+                        email_data["email_notes"] = None
+
+                    if email_data["email_notes"]:
+                        with open(os.path.expanduser(email_data["email_notes"])) as f:
+                            email_data["email_notes"] = f.read().replace("\n", "<br />")
                     else:
                         email_data["email_notes"] = buisciii.utils.ask_for_some_text(
                             msg="Write email notes"

--- a/buisciii/templates/IRMA/ANALYSIS/ANALYSIS01_IRMA/99-stats/lablog
+++ b/buisciii/templates/IRMA/ANALYSIS/ANALYSIS01_IRMA/99-stats/lablog
@@ -159,12 +159,11 @@ echo "
     pc_genome_greater_10x=\$(printf \"%s\\n\" \"\${pc10x[@]}\" | sort -n | awk '{sum+=\$1} END {printf \"%.2f\", (NR ? sum/NR : 0)}')
     virus_sequence=\$(awk -v sample=\"\${in}\" '\$1 == sample {ref = ref ? ref \",\" \$4 : \$4} END {if (ref) print ref}' ../06-variant-calling/sample_type_ref.txt)
     total_reads=\$(grep \"\\\"total_reads\\\"\" ../02-preprocessing/\${in}/\${in}_fastp.json | head -n1 | cut -d \":\" -f2 | sed \"s/,//g\")
-    reads_hostR1=\$(cat ../../*_TAXPROFILER/kraken2/*/\${in}_*.kraken2.report.txt | grep \"Homo sapiens\" | awk '{print \$2}')
-    reads_host_x2=\$((reads_hostR1 * 2))
-    pc_reads_host=\$(awk -v v1=\$total_reads -v v2=\$reads_host_x2 'BEGIN {printf \"%.2f\", (v2*100)/v1}')
+    reads_host=\$(awk -v sample=\"\${in}_run1\" '\$1 == sample {print int(\$2)}' ../../*_TAXPROFILER/multiqc/multiqc_data/samtools_alignment_plot.txt)
+    pc_reads_host=\$(awk -v v1=\$total_reads -v v2=\$reads_host 'BEGIN {printf \"%.2f\", (v2*100)/v1}')
     reads_virus=\$(awk -F\"\t\" -v id=\"\$in\" '\$1 == id {print \$3}' ../04-irma/irma_stats_flu.txt)
     pc_reads_virus=\$(awk -v v1=\$reads_virus -v v2=\$total_reads 'BEGIN {if (v2 > 0) printf \"%.2f\", (v1 / v2) * 100; else print \"NA\"}')
-    unmapped_reads=\$((total_reads - (reads_host_x2+reads_virus)))
+    unmapped_reads=\$((total_reads - (reads_host+reads_virus)))
     pc_unmapped=\$(awk -v v1=\$total_reads -v v2=\$unmapped_reads  'BEGIN {printf \"%.2f\", (v2/v1)*100}')
     qc_filtered=\$(grep \"\\\"total_reads\\\"\" ../02-preprocessing/\${in}/\${in}_fastp.json | head -n2 | tail -n1 | cut -d \":\" -f2 | sed \"s/,//g\")
     read_length=\$(unzip -p ../03-procQC/\${in}/\${in}_R1_filtered_fastqc.zip */fastqc_data.txt | grep \"Sequence length\" | cut -d \"-\" -f2)
@@ -206,7 +205,7 @@ echo "
     variants_PB1=\${variants[PB1]}
     variants_PB2=\${variants[PB2]}
 
-    echo -e \"\${in}\t\$virus_sequence\t\$flu_type\t\$flu_subtype\t\$clade\t\$clade_assignment_date\t\$clade_assignment_software_database_version\t\$total_reads\t\$qc_filtered\t\$reads_host_x2\t\$pc_reads_host\t\$reads_virus\t\$pc_reads_virus\t\$unmapped_reads\t\$pc_unmapped\t\$coverage_depth\t\$pc_genome_greater_10x\t\$pc_Ns\t\$variants_in_consensus\t\$variants_with_effect\t\$number_unambiguous_bases\t\$number_Ns\t\$read_length\t\$analysis_date\t\$cov_HA\t\$cov_MP\t\$cov_NA\t\$cov_NP\t\$cov_NS\t\$cov_PA\t\$cov_PB1\t\$cov_PB2\t\$cov10x_HA\t\$cov10x_MP\t\$cov10x_NA\t\$cov10x_NP\t\$cov10x_NS\t\$cov10x_PA\t\$cov10x_PB1\t\$cov10x_PB2\t\$perNs_HA\t\$perNs_MP\t\$perNs_NA\t\$perNs_NP\t\$perNs_NS\t\$perNs_PA\t\$perNs_PB1\t\$perNs_PB2\t\$variants_HA\t\$variants_MP\t\$variants_NA\t\$variants_NP\t\$variants_NS\t\$variants_PA\t\$variants_PB1\t\$variants_PB2\" >> summary_stats_\$(date \"+%Y%m%d\").tab
+    echo -e \"\${in}\t\$virus_sequence\t\$flu_type\t\$flu_subtype\t\$clade\t\$clade_assignment_date\t\$clade_assignment_software_database_version\t\$total_reads\t\$qc_filtered\t\$reads_host\t\$pc_reads_host\t\$reads_virus\t\$pc_reads_virus\t\$unmapped_reads\t\$pc_unmapped\t\$coverage_depth\t\$pc_genome_greater_10x\t\$pc_Ns\t\$variants_in_consensus\t\$variants_with_effect\t\$number_unambiguous_bases\t\$number_Ns\t\$read_length\t\$analysis_date\t\$cov_HA\t\$cov_MP\t\$cov_NA\t\$cov_NP\t\$cov_NS\t\$cov_PA\t\$cov_PB1\t\$cov_PB2\t\$cov10x_HA\t\$cov10x_MP\t\$cov10x_NA\t\$cov10x_NP\t\$cov10x_NS\t\$cov10x_PA\t\$cov10x_PB1\t\$cov10x_PB2\t\$perNs_HA\t\$perNs_MP\t\$perNs_NA\t\$perNs_NP\t\$perNs_NS\t\$perNs_PA\t\$perNs_PB1\t\$perNs_PB2\t\$variants_HA\t\$variants_MP\t\$variants_NA\t\$variants_NP\t\$variants_NS\t\$variants_PA\t\$variants_PB1\t\$variants_PB2\" >> summary_stats_\$(date \"+%Y%m%d\").tab
     echo -e \"-----Statistics for \$in correctly added into summary_stats_\$(date \"+%Y%m%d\").tab-----\n\"
     unset gene_coverage coverages_10x per_Ns variants
   done


### PR DESCRIPTION
<!--
# bu-isciii tools pull request

Based on nf-core/viralrecon pull request template

Fill in the appropriate checklist below and delete whatever is not relevant.

PRs should be made against the develop of hotfix branch, unless you're preparing a software release.
-->

## PR checklist

- [X] This comment contains a description of changes (with reason).
- [X] Make sure your code lints (`black and flake8`).
- If a new tamplate was added make sure:
    - [ ] Template's schema is added in `templates/services.json`.
    - [ ] Template's pipeline's documentation in `assets/reports/md/template.md` is added.
    - [ ] Results Documentation in `assets/reports/results/template.md` is updated.
- [X] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
- [ ] If you know a new user was added to the SFTP, make sure you added it to `templates/sftp_user.json`

## PR description

This PR fixes:
* `__main__.py` so that the `clean` module is run correctly when running `finish`.
* The `bioinfo_doc` module so that a text file can correctly be used for email notes.
* The IRMA's 99-stats lablog so that the number of host reads is taken from `samtools stats` (taxprofiler), instead of kraken.

This PR closes #563.