### PR TITLE
Fix `pkg_resources` installation error and update `bacass` version in `Assembly` template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Credits
 
 - [Victor Lopez](https://github.com/victor5lm)
+- [Alejandro Bernabeu](https://github.com/Aberdur)
 
 ### Template fixes and updates
 
 - Updated sftp_user.json [#568](https://github.com/BU-ISCIII/buisciii-tools/pull/568).
 - Fixed the parse_ariba.py script and stored in the 99-stats folder from the CHARACTERIZATION template [#568](https://github.com/BU-ISCIII/buisciii-tools/pull/568).
 - Updated IRMA template to comply with new sample id format in relecov analysis [578](https://github.com/BU-ISCIII/buisciii-tools/pull/578)
+- Fix pkg_resources installation error and pin bacass version in Assembly template [579](https://github.com/BU-ISCIII/buisciii-tools/pull/579)
 
 ### Modules
 

--- a/buisciii/templates/assembly/ANALYSIS/ANALYSIS01_ASSEMBLY/lablog
+++ b/buisciii/templates/assembly/ANALYSIS/ANALYSIS01_ASSEMBLY/lablog
@@ -107,7 +107,7 @@ cat <<EOF > assembly.sbatch
 # module load Nextflow/23.10.0 singularity
 export NXF_OPTS="-Xms500M -Xmx8G"
 
-nextflow run /data/ucct/bi/pipelines/nf-core-bacass/nf-core-bacass-2.4.0/2_4_0/main.nf \\
+nextflow run /data/ucct/bi/pipelines/nf-core-bacass/nf-core-bacass-2.3.1/main.nf \\
         -c ../../DOC/hpc_slurm_assembly.config \\
         -profile singularity \\
         --input samplesheet.csv \\

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ pymdown-extensions>=10.4
 pdfkit>=1.0.0
 PyPDF2>=3.0.1
 PyYAML>=6.0.2
+setuptools>=68


### PR DESCRIPTION
<!--
# bu-isciii tools pull request

Based on nf-core/viralrecon pull request template

Fill in the appropriate checklist below and delete whatever is not relevant.

PRs should be made against the develop of hotfix branch, unless you're preparing a software release.
-->
## PR Description
1) Fix ModuleNotFoundError: No module named 'pkg_resources' during installation by installing setuptools in requirements
2) Update bacass version to 2.3.1

Problem

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`black and flake8`).
- If a new tamplate was added make sure:
    - [ ] Template's schema is added in `templates/services.json`.
    - [ ] Template's pipeline's documentation in `assets/reports/md/template.md` is added.
    - [ ] Results Documentation in `assets/reports/results/template.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
- [ ] If you know a new user was added to the SFTP, make sure you added it to `templates/sftp_user.json`
