### PR TITLE
Replace MTBseq with TBProfiler in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,12 +126,9 @@ Output:
 ┡━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
 │    assembly_annotation │ Nextflow assembly pipeline to assemble    │ https://github.com/Daniel-VM/bacass/...    │
 │                        │ bacterial genomes                         │                                            │
-│        mtbseq_assembly │ Mycobacterium tuberculosis mapping,       │ https://github.com/ngs-fzb/MTBseq_source   │
-│                        │ variant calling and detection of          │                                            │
-│                        │ resistance using MTBseq                   │                                            │
-│                 mtbseq │ Mycobacterium tuberculosis mapping,       │ https://github.com/ngs-fzb/MTBseq_source   │
-│                        │ variant calling and detection of          │                                            │
-│                        │ resistance using MTBseq                   │                                            │
+│             tbprofiler │ Mycobacterium tuberculosis variant        │ https://github.com/jodyphelan/TBProfiler   │
+│                        │ calling and resistance prediction using   │                                            │
+│                        │ TBProfiler                                │                                            │
 │              pikavirus │ PikaVirus, a mapping-based tool for       │ https://github.com/BU-ISCIII/PikaVirus     │
 │                        │ metagenome analysis of virus.             │                                            │
 │     plasmidid_assembly │ Plasmid identification tool based on      │ https://github.com/BU-ISCIII/plasmidID     │
@@ -150,11 +147,6 @@ Output:
 │       seek_and_destroy │ Simple pipeline for basic quality         │ https://github.com/GuilleGorines/Seek-Des… │
 │                        │ control, host removal and exploratory     │                                            │
 │                        │ analysis of samples.                      │                                            │
-│ ariba_characterization │                                           │                                            │
-│                mag_met │ 1- Bioinformatics best-practise analysis  │ https://github.com/nf-core/mag or          │
-│                        │ for taxonomic classification and          │ https://github.com/nf-core/taxprofiler     │
-│                        │ profiling; 2- Bioinformatics best-practise│                                            │
-│                        │ analysis pipeline for assembly, binning   │                                            │
 └────────────────────────┴───────────────────────────────────────────┴────────────────────────────────────────────┘
 ```
 


### PR DESCRIPTION
### Changes made
Issue #593: Update README.md to reflect replacement of MTBseq with TBProfiler in the services table.
- Removed mtbseq and mtbseq_assembly entries.
- Added tbprofiler entry with updated label, description, and GitHub link.
- Adjusted table format for consistency.

Closes #593

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`black and flake8`).
- If a new tamplate was added make sure:
    - [ ] Template's schema is added in `templates/services.json`.
    - [ ] Template's pipeline's documentation in `assets/reports/md/template.md` is added.
    - [ ] Results Documentation in `assets/reports/results/template.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated (including new tool citations and authors/contributors).
- [ ] If you know a new user was added to the SFTP, make sure you added it to `templates/sftp_user.json`
