### PR TITLE
Replace mtbseq with tbprofiler in templates/services.json (follow-up to #596)

### DIFF
--- a/buisciii/templates/services.json
+++ b/buisciii/templates/services.json
@@ -16,22 +16,22 @@
         "delivery_md": "assets/reports/md/assembly.md",
         "results_md": "assets/reports/results/assembly.md"
     },
-    "mtbseq": {
-        "label": "Bacteria: In-depth analysis of Mycobacterium species genomes (e.g. M. tuberculosis. M. bovis)",
-        "template": "mtbseq",
+    "tbprofiler": {
+        "label": "Bacteria: In-depth analysis of Mycobacterium species genomes using TBProfiler",
+        "template": "tbprofiler",
         "order": 1,
         "begin": "base",
         "end": "",
-        "url": "https://github.com/ngs-fzb/MTBseq_source",
-        "description": "Mycobacterium tuberculosis mapping, variant calling and detection of resistance using MTBseq",
+        "url": "https://github.com/jodyphelan/TBProfiler",
+        "description": "Mycobacterium tuberculosis variant calling and resistance prediction using TBProfiler",
         "clean": {
           "folders":["01-preprocessing", "Bam", "Mpileup"],
           "files":["01-processing/fastp/sample_name_1.fastp.fastq.gz", "01-processing/fastp/sample_name_2.fastp.fastq.gz"]
         },
         "no_copy": ["RAW", "TMP"],
         "last_folder":"REFERENCES",
-        "delivery_md": "",
-        "results_md": ""
+        "delivery_md": "assets/reports/md/tbprofiler_delivery.md",
+        "results_md": "assets/reports/results/tbprofiler_results.md"
     },
     "pikavirus": {
       "label": "Viral: Detection and characterization of viral genomes within metagenomic data",

--- a/buisciii/templates/sftp_user.json
+++ b/buisciii/templates/sftp_user.json
@@ -59,6 +59,5 @@
     "nlabiod": ["Labarbovirus"],
     "jmgonzalez": ["Lablegionella"],
     "alberto.campoy": ["Labvirusres"],
-    "pberzosa": ["LabMalariaNTD"],
-    "mcoiras": ["LabvirusVIH"]
+    "pberzosa": ["LabMalariaNTD"]
 }


### PR DESCRIPTION
Recreates PR #596 after cleaning unrelated changes. Modifies `services.json` as intended for issue #594.

### Changes made:

Issue #594: Replaced mtbseq with tbprofiler in buisciii/templates/services.json.
- Updated label, template, URL, and description.
- Adjusted delivery_md and results_md to point to the correct TBProfiler files.
- The clean, no_copy, and last_folder structure remains the same as mtbseq.

Closes #594

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] Make sure your code lints (`black and flake8`).
- If a new tamplate was added make sure:
    - [x] Template's schema is added in `templates/services.json`.
    - [ ] Template's pipeline's documentation in `assets/reports/md/template.md` is added.
    - [ ] Results Documentation in `assets/reports/results/template.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
- [ ] If you know a new user was added to the SFTP, make sure you added it to `templates/sftp_user.json`
