### PR TITLE
Modified in create_assembly_stats.R so groups by sample

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.1dev] - 2026-XX-XX : https://github.com/BU-ISCIII/buisciii-tools/releases/tag/2.3.0
+
+### Credits
+
+- [Pau Pascual](https://github.com/PauPascualMas)
+
+### Template fixes and updates
+
+- Modified `create_assembly_stats.R` to group by sample in viralrecon template [#631](https://github.com/BU-ISCIII/buisciii-tools/pull/631)
 
 ## [2.3.0] - 2025-02-09 : https://github.com/BU-ISCIII/buisciii-tools/releases/tag/2.3.0
 

--- a/buisciii/templates/viralrecon/ANALYSIS/create_assembly_stats.R
+++ b/buisciii/templates/viralrecon/ANALYSIS/create_assembly_stats.R
@@ -124,8 +124,30 @@ df_final[, columnas_ch] <- apply(df_final[, columnas_ch], 2, function(x) as.char
 columnas_nu <- as.vector(6:length(colnames(df_final)))
 df_final[, columnas_nu] <- apply(df_final[, columnas_nu], 2, function(x) as.numeric(as.character(x)))
 
+# group by sample
+df_grouped <- df_final %>%
+  group_by(sample) %>%
+  summarise(
+    run = first(run),
+    user = first(user),
+    host = first(host),
+
+    Virussequence = paste(unique(Virussequence), collapse = ","),
+
+    totalreads = first(totalreads),
+    readshostR1 = first(readshostR1),
+    readshost = first(readshost),
+    `%readshost` = first(`%readshost`),
+    `Non-host-reads` = first(`Non-host-reads`),
+    `%Non-host-reads` = first(`%Non-host-reads`),
+    Contigs = if (all(is.na(Contigs))) NA else max(Contigs, na.rm = TRUE),
+    Largest_contig = if (all(is.na(Largest_contig))) NA else max(Largest_contig, na.rm = TRUE),
+    `%Genome_fraction` = if (all(is.na(`%Genome_fraction`))) NA else max(`%Genome_fraction`, na.rm = TRUE),
+    .groups = "drop"
+  )
+
 # Write table csv
-write.table(df_final, "assembly_stats.csv", row.names = F, col.names = T, sep = "\t", quote = F)
+write.table(df_grouped, "assembly_stats.csv", row.names = F, col.names = T, sep = "\t", quote = F)
 
 # Write table xlsx
-write_xlsx(df_final, "assembly_stats.xlsx", format_headers = F)
+write_xlsx(df_grouped, "assembly_stats.xlsx", format_headers = F)


### PR DESCRIPTION
<!--
# bu-isciii tools pull request

Based on nf-core/viralrecon pull request template

Fill in the appropriate checklist below and delete whatever is not relevant.

PRs should be made against the develop of hotfix branch, unless you're preparing a software release.
-->

This PR improves the create_assembly_stats.R script by:

- Grouping results by sample to produce one row per sample
- Combining multiple virus references into a single comma-separated Virussequence column
- Modifies CHANGELOG.md

Resolves #629 

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`black and flake8`).
- If a new tamplate was added make sure:
    - [ ] Template's schema is added in `templates/services.json`.
    - [ ] Template's pipeline's documentation in `assets/reports/md/template.md` is added.
    - [ ] Results Documentation in `assets/reports/results/template.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
- [ ] If you know a new user was added to the SFTP, make sure you added it to `templates/sftp_user.json`
