### PR TITLE
Fixed tbprofiler results_md path in services.json (fixes #638)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - [Pau Pascual](https://github.com/PauPascualMas)
 - [Victor Lopez](https://github.com/victor5lm)
+- [Magdalena Matito](https://github.com/magdasmat)
 
 ### Template fixes and updates
 
 - Modified `create_assembly_stats.R` to group by sample in viralrecon template [#631](https://github.com/BU-ISCIII/buisciii-tools/pull/631).
 - Fixed error handling in finish module and automatic logging for new_service [#632](https://github.com/BU-ISCIII/buisciii-tools/pull/632).
 - Solved symlink path for TBProfiler results lablog [#634](https://github.com/BU-ISCIII/buisciii-tools/pull/634)
-
+- Fixed tbprofiler `delivery_md` and `results_md` paths in `buisciii/templates/services.json` [#640](https://github.com/BU-ISCIII/buisciii-tools/pull/640)
 
 ### Modules
 

--- a/buisciii/templates/services.json
+++ b/buisciii/templates/services.json
@@ -30,8 +30,8 @@
         },
         "no_copy": ["RAW", "TMP"],
         "last_folder":"REFERENCES",
-        "delivery_md": "assets/reports/md/tbprofiler_delivery.md",
-        "results_md": "assets/reports/results/tbprofiler_results.md"
+        "delivery_md": "assets/reports/md/tbprofiler.md",
+        "results_md": "assets/reports/results/tbprofiler.md"
     },
     "pikavirus": {
       "label": "Viral: Detection and characterization of viral genomes within metagenomic data",


### PR DESCRIPTION
## Description
Fixed wrong file paths for `delivery_md` and `results_md` fields in the `tbprofiler` service entry in `buisciii/templates/services.json`.

- `delivery_md` path: `assets/reports/md/tbprofiler_delivery.md` → `assets/reports/md/tbprofiler.md`
- `results_md` path: `assets/reports/results/tbprofiler_results.md` → `assets/reports/results/tbprofiler.md`

Closes #638

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`black and flake8`).
- If a new tamplate was added make sure:
    - [ ] Template's schema is added in `templates/services.json`.
    - [ ] Template's pipeline's documentation in `assets/reports/md/template.md` is added.
    - [ ] Results Documentation in `assets/reports/results/template.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
- [ ] If you know a new user was added to the SFTP, make sure you added it to `templates/sftp_user.json`
