### PR TITLE
IRMA's 99-stats summary stat creation now runs in parallel. Fixes #630

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.3dev] - 2026-XX-XX : https://github.com/BU-ISCIII/buisciii-tools/releases/tag/2.3.3dev
+
+### Credits
+
+- [Enrique Sapena](https://github.com/ESapenaVentura)
+
+### Template fixes and updates
+
+- Added parallelization to IRMA's 99-stats summary creation. [#648](https://github.com/BU-ISCIII/buisciii-tools/pull/648)
+
+### Modules
+
+#### Added enhancements
+
+#### Fixes
+
+#### Changed
+
+#### Removed
+
+### Requirements
+
 ## [2.3.2] - 2026-03-31 : https://github.com/BU-ISCIII/buisciii-tools/releases/tag/2.3.2
 
 ### Credits

--- a/buisciii/templates/IRMA/ANALYSIS/ANALYSIS01_IRMA/99-stats/lablog
+++ b/buisciii/templates/IRMA/ANALYSIS/ANALYSIS01_IRMA/99-stats/lablog
@@ -245,7 +245,7 @@ bash aux_create_summary_stats.sh \"\$in\"
 
 echo "jobid=\$(sbatch --parsable _05_create_summary_stats.sbatch)
 # Clean after batch job - merge stats and remove tmp files
-sbatch --dependency=afterok:\$jobid <<EOF
+sbatch --dependency=afterok:\$jobid <<'EOF'
 #!/usr/bin/env bash
 #SBATCH --job-name=merge_stats
 #SBATCH --output=logs/MERGE_STATS.$(date "+%Y%m%d").log

--- a/buisciii/templates/IRMA/ANALYSIS/ANALYSIS01_IRMA/99-stats/lablog
+++ b/buisciii/templates/IRMA/ANALYSIS/ANALYSIS01_IRMA/99-stats/lablog
@@ -71,7 +71,7 @@ echo "
 " > _04_get_qc_metrics.sh
 
 # Create a table with relevant statistics.
-echo "
+echo "#!/usr/bin/env bash
   # Verify that Taxprofiler results exist before proceeding
   TAXPROFILER_DIR=\$(find ../../ -type d -name '*_TAXPROFILER' | head -n 1)
 
@@ -83,143 +83,176 @@ echo "
   # Activate the conda environment
   eval \"\$(micromamba shell hook --shell bash)\"
   micromamba activate refgenie_v0.12.1
-  HEADER=\"sample\tVirussequence\tflu_type\tflu_subtype\tclade\tclade_assignment_date\tclade_assignment_software_database_version\ttotalreads\tqc_filtered_reads\treads_host\t%readshost\treads_virus\t%readsvirus\tunmapped_reads\t%unmappedreads\tmedianDPcoveragevirus\tCoverage>10x(%)\t%Ns10x\tVariantsinconsensusx10\tMissenseVariants\tTotal_Unambiguous_Bases\tTotal_Ns_count\tread_length\tanalysis_date\tmedianDPcoveragevirusHA\tmedianDPcoveragevirusMP\tmedianDPcoveragevirusNA\tmedianDPcoveragevirusNP\tmedianDPcoveragevirusNS\tmedianDPcoveragevirusPA\tmedianDPcoveragevirusPB1\tmedianDPcoveragevirusPB2\tCoverage>10xHA(%)\tCoverage>10xMP(%)\tCoverage>10xNA(%)\tCoverage>10xNP(%)\tCoverage>10xNS(%)\tCoverage>10xPA(%)\tCoverage>10xPB1(%)\tCoverage>10xPB2(%)\tperNs_HA\tperNs_MP\tperNs_NA\tperNs_NP\tperNs_NS\tperNs_PA\tperNs_PB1\tperNs_PB2\tvariants_HA\tvariants_MP\tvariants_NA\tvariants_NP\tvariants_NS\tvariants_PA\tvariants_PB1\tvariants_PB2\"
-  echo -e \${HEADER} > summary_stats_\$(date \"+%Y%m%d\").tab
 
-  while read in; do
+  in=\"\$1\"
 
-    echo -e \"-----Adding statistics for \$in in summary_stats_\$(date \"+%Y%m%d\").tab-----\"
-    declare -A gene_coverage
-    coverage_medians=()
-    for file in ${scratch_dir}/../04-irma/\${in}/tables/*-coverage.txt; do
-      fragment=\$(basename \$file | cut -d \"_\" -f 2 | cut -d \"-\" -f 1)
-      cov_median=\$(awk 'NR>1 {print \$3}' \"\$file\" | sort -n | awk '{a[NR]=\$1} END {print (NR%2==1)? a[(NR+1)/2] : (a[NR/2] + a[NR/2+1]) / 2}')
-      gene_coverage[\"\$fragment\"]=\"\$cov_median\"
-      coverage_medians+=(\"\$cov_median\")
+  echo -e \"-----Adding statistics for \$in\"
+  declare -A gene_coverage
+  coverage_medians=()
+  for file in ${scratch_dir}/../04-irma/\${in}/tables/*-coverage.txt; do
+    fragment=\$(basename \$file | cut -d \"_\" -f 2 | cut -d \"-\" -f 1)
+    cov_median=\$(awk 'NR>1 {print \$3}' \"\$file\" | sort -n | awk '{a[NR]=\$1} END {print (NR%2==1)? a[(NR+1)/2] : (a[NR/2] + a[NR/2+1]) / 2}')
+    gene_coverage[\"\$fragment\"]=\"\$cov_median\"
+    coverage_medians+=(\"\$cov_median\")
+  done
+
+  declare -A variants
+  variants_consensus=()
+  vcf_path=\"${scratch_dir}/../06-variant-calling/vcf_files/\${in}/\${in}_*.vcf\"
+
+  if ls \$vcf_path 1> /dev/null 2>&1; then
+    for file in \$vcf_path; do
+      fragment=\$(basename \$file | sed -E 's/^.*_([^_]+)\\.vcf$/\1/')
+      variant=\$(grep -v \"^#\" \"\$file\" | grep -c \"consensus\")
+      variants[\"\$fragment\"]=\"\$variant\"
+      variants_consensus+=(\"\$variant\")
     done
+  else
+    echo \"-----No VCF file found for \${in} and \${fragment}.-----\"
+  fi
 
-    declare -A variants
-    variants_consensus=()
-    vcf_path=\"${scratch_dir}/../06-variant-calling/vcf_files/\${in}/\${in}_*.vcf\"
-
-    if ls \$vcf_path 1> /dev/null 2>&1; then
-      for file in \$vcf_path; do
-        fragment=\$(basename \$file | sed -E 's/^.*_([^_]+)\\.vcf$/\1/')
-        variant=\$(grep -v \"^#\" \"\$file\" | grep -c \"consensus\")
-        variants[\"\$fragment\"]=\"\$variant\"
-        variants_consensus+=(\"\$variant\")
-      done
-    else
-      echo \"-----No VCF file found for \${in} and \${fragment}.-----\"
+  declare -A coverages_10x
+  pc10x=()
+  declare -A genome_sizes
+  for file in ${scratch_dir}/../04-irma/\${in}/tables/*-coverage.txt; do
+    fragment=\$(basename \$file | cut -d \"_\" -f 2 | cut -d \"-\" -f 1)
+    ref=\$(awk -v sample=\"\$in\" -v frag=\"\$fragment\" '\$1 == sample && \$3 == frag {print \$4; exit}' sample_type_ref.txt)
+    if [ -z \"\$ref\" ]; then
+      echo \"WARNING: No reference found for sample=\$in and fragment=\$fragment\"
+      continue
     fi
 
-    declare -A coverages_10x
-    pc10x=()
-    for file in ${scratch_dir}/../04-irma/\${in}/tables/*-coverage.txt; do
-      fragment=\$(basename \$file | cut -d \"_\" -f 2 | cut -d \"-\" -f 1)
-      ref=\$(awk -v sample=\"\$in\" -v frag=\"\$fragment\" '\$1 == sample && \$3 == frag {print \$4; exit}' sample_type_ref.txt)
-      if [ -z \"\$ref\" ]; then
-        echo \"WARNING: No reference found for sample=\$in and fragment=\$fragment\"
-        continue
-      fi
-      genome_size=\$(cat \$(refgenie seek orthomyxoviridae/fasta:\${ref} -c /data/ucct/bi/references/refgenie/genome_config.yaml) | grep -v \"^>\" | tr -d \"\n\" | wc -m)
-      cov10xpositions=\$(tail -n +2 \"\$file\" | awk '\$3 >= 10 {count++} END {if (count > 0) {print count} else {print 0}}')
-      per_cov10x=\$(awk \"BEGIN {printf \\\"%.2f\\\\n\\\", (\${cov10xpositions} / \${genome_size}) * 100}\")
-      coverages_10x[\"\$fragment\"]=\"\$per_cov10x\"
-      pc10x+=(\"\$per_cov10x\")
-    done
-
-    declare -A per_Ns
-    ns_values=()
-    while IFS=\$'\\t' read -r sample ns_value; do
-      if \$(echo \$sample | grep -q \$in ); then
-        fragment=\"\${sample##*_}\"
-        ns_values+=(\"\$ns_value\")
-        per_Ns[\"\$fragment\"]=\"\$ns_value\"
-      else
-        formatted_sample_name=\$(echo \$in | sed \"s/-/\\//g\")
-        if  \$(echo \$sample | grep -q \$formatted_sample_name); then
-			fragment=\"\${sample##*_}\"
-			ns_values+=(\"\$ns_value\")
-			per_Ns[\"\$fragment\"]=\"\$ns_value\"
-        fi
-      fi
-    done < \"%Ns.tab\"
-
-    if [ \${#ns_values[@]} -gt 0 ]; then
-      total_ns=0
-      for ns in \"\${ns_values[@]}\"; do
-        total_ns=\$(echo \"\$total_ns + \$ns\" | bc)
-      done
-      pc_Ns=\$(printf \"%.2f\" \"\$(echo \"\$total_ns / \${#ns_values[@]}\" | bc -l)\")
-    else
-      pc_Ns=\"NA\"
+    if [[ -z \"\${genome_sizes[\$ref]:-}\" ]]; then
+      fasta=\$(refgenie seek orthomyxoviridae/fasta:\${ref} -c /data/ucct/bi/references/refgenie/genome_config.yaml)
+      genome_sizes[\$ref]=\$(grep -v \"^>\" \"\$fasta\" | tr -d \"\n\" | wc -m)
     fi
+    genome_size=\${genome_sizes[\$ref]}
+    cov10xpositions=\$(tail -n +2 \"\$file\" | awk '\$3 >= 10 {count++} END {if (count > 0) {print count} else {print 0}}')
+    per_cov10x=\$(awk \"BEGIN {printf \\\"%.2f\\\\n\\\", (\${cov10xpositions} / \${genome_size}) * 100}\")
+    coverages_10x[\"\$fragment\"]=\"\$per_cov10x\"
+    pc10x+=(\"\$per_cov10x\")
+  done
 
-    analysis_date=\$(date \"+%Y-%m-%d\")
-    flu_type=\$(awk -F '\t' -v sample=\"\$in\" '\$1 == sample {print \$5; exit}' ../04-irma/irma_stats_flu.txt | cut -d \"_\" -f 1)
-    flu_subtype=\$(awk -F '\t' -v sample=\"\$in\" '\$1 == sample {split(\$5, parts, \"_\"); if (length(parts) >= 3) print parts[2] parts[3]; exit}' ../04-irma/irma_stats_flu.txt)
-    coverage_depth=\$(printf \"%s\\n\" \"\${coverage_medians[@]}\" | sort -n | awk '{a[NR]=\$1} END {print (NR%2==1)? a[(NR+1)/2] : (a[NR/2] + a[NR/2+1]) / 2}')
-    variants_in_consensus=\$(printf \"%s\\n\" \"\${variants_consensus[@]}\" | awk '{sum+=\$1} END{print sum}')
-    variants_with_effect=\$(awk -F, -v sample=\"\$in\" '\$1 == sample && \$8 == \"consensus\" && \$14 == \"missense_variant\" {count++} END {print count+0}' variants_long_table.csv)
-    pc_genome_greater_10x=\$(printf \"%s\\n\" \"\${pc10x[@]}\" | sort -n | awk '{sum+=\$1} END {printf \"%.2f\", (NR ? sum/NR : 0)}')
-    virus_sequence=\$(awk -v sample=\"\${in}\" '\$1 == sample {ref = ref ? ref \",\" \$4 : \$4} END {if (ref) print ref}' ../06-variant-calling/sample_type_ref.txt)
-    total_reads=\$(grep \"\\\"total_reads\\\"\" ../02-preprocessing/\${in}/\${in}_fastp.json | head -n1 | cut -d \":\" -f2 | sed \"s/,//g\")
-    reads_host=\$(awk -v sample=\"\${in}_run1\" '\$1 == sample {print int(\$2)}' ../../*_TAXPROFILER/multiqc/multiqc_data/samtools_alignment_plot.txt)
-    pc_reads_host=\$(awk -v v1=\$total_reads -v v2=\$reads_host 'BEGIN {printf \"%.2f\", (v2*100)/v1}')
-    reads_virus=\$(awk -F\"\t\" -v id=\"\$in\" '\$1 == id {print \$3}' ../04-irma/irma_stats_flu.txt)
-    pc_reads_virus=\$(awk -v v1=\$reads_virus -v v2=\$total_reads 'BEGIN {if (v2 > 0) printf \"%.2f\", (v1 / v2) * 100; else print \"NA\"}')
-    unmapped_reads=\$((total_reads - (reads_host+reads_virus)))
-    pc_unmapped=\$(awk -v v1=\$total_reads -v v2=\$unmapped_reads  'BEGIN {printf \"%.2f\", (v2/v1)*100}')
-    qc_filtered=\$(grep \"\\\"total_reads\\\"\" ../02-preprocessing/\${in}/\${in}_fastp.json | head -n2 | tail -n1 | cut -d \":\" -f2 | sed \"s/,//g\")
-    read_length=\$(unzip -p ../03-procQC/\${in}/\${in}_R1_filtered_fastqc.zip */fastqc_data.txt | grep \"Sequence length\" | cut -d \"-\" -f2)
-    number_unambiguous_bases=\$(awk -F \"\t\" -v id=\"\$in\" '\$1 == id {print \$2}' qc_metrics.tsv)
-    number_Ns=\$(awk -F \"\t\" -v id=\"\$in\" '\$1 == id {print \$3}' qc_metrics.tsv)
-    if grep -q \$in ../05-nextclade/nextclade_combined.csv; then
-    	clade=\$(awk -F \";\" -v sample="\$in" '\$2 ~ sample {print \$3}' ../05-nextclade/nextclade_combined.csv)
-	else
-		clade=\$(awk -F \";\" -v sample=\"\$(echo \$in | sed \"s/-/\\//g\")_HA\" '\$2 == sample {print \$3}' ../05-nextclade/nextclade_combined.csv)
-	fi
-    clade_assignment_date=\$(cat ../05-nextclade/\${flu_type}*/nextclade.json | awk -F'\"' '/createdAt/ {print \$4}' | cut -d 'T' -f 1 | tr -d '-' | head -n 1 | sed 's/\(....\)\(..\)\(..\)/\1-\2-\3/')
-    clade_assignment_software_database_version=\$(cat ../05-nextclade/logs/NEXTCLADE_RUN_\${flu_type}_\$(echo \${flu_subtype} | cut -d \"N\" -f 1)*.log | grep -oE '[0-9]{4}-[0-9]{2}-[0-9]{2}--[0-9]{2}-[0-9]{2}-[0-9]{2}Z' | head -n 1)
-    cov_HA=\${gene_coverage[HA]}
-    cov_MP=\${gene_coverage[MP]}
-    cov_NA=\${gene_coverage[NA]}
-    cov_NP=\${gene_coverage[NP]}
-    cov_NS=\${gene_coverage[NS]}
-    cov_PA=\${gene_coverage[PA]}
-    cov_PB1=\${gene_coverage[PB1]}
-    cov_PB2=\${gene_coverage[PB2]}
-    cov10x_HA=\${coverages_10x[HA]}
-    cov10x_MP=\${coverages_10x[MP]}
-    cov10x_NA=\${coverages_10x[NA]}
-    cov10x_NP=\${coverages_10x[NP]}
-    cov10x_NS=\${coverages_10x[NS]}
-    cov10x_PA=\${coverages_10x[PA]}
-    cov10x_PB1=\${coverages_10x[PB1]}
-    cov10x_PB2=\${coverages_10x[PB2]}
-    perNs_HA=\${per_Ns[HA]}
-    perNs_MP=\${per_Ns[MP]}
-    perNs_NA=\${per_Ns[NA]}
-    perNs_NP=\${per_Ns[NP]}
-    perNs_NS=\${per_Ns[NS]}
-    perNs_PA=\${per_Ns[PA]}
-    perNs_PB1=\${per_Ns[PB1]}
-    perNs_PB2=\${per_Ns[PB2]}
-    variants_HA=\${variants[HA]}
-    variants_MP=\${variants[MP]}
-    variants_NA=\${variants[NA]}
-    variants_NP=\${variants[NP]}
-    variants_NS=\${variants[NS]}
-    variants_PA=\${variants[PA]}
-    variants_PB1=\${variants[PB1]}
-    variants_PB2=\${variants[PB2]}
+  declare -A per_Ns
+  ns_values=()
+  while IFS=\$'\\t' read -r sample ns_value; do
+    if \$(echo \$sample | grep -q \$in ); then
+      fragment=\"\${sample##*_}\"
+      ns_values+=(\"\$ns_value\")
+      per_Ns[\"\$fragment\"]=\"\$ns_value\"
+    else
+      formatted_sample_name=\$(echo \$in | sed \"s/-/\\//g\")
+      if  \$(echo \$sample | grep -q \$formatted_sample_name); then
+    fragment=\"\${sample##*_}\"
+    ns_values+=(\"\$ns_value\")
+    per_Ns[\"\$fragment\"]=\"\$ns_value\"
+      fi
+    fi
+  done < \"%Ns.tab\"
 
-    echo -e \"\${in}\t\$virus_sequence\t\$flu_type\t\$flu_subtype\t\$clade\t\$clade_assignment_date\t\$clade_assignment_software_database_version\t\$total_reads\t\$qc_filtered\t\$reads_host\t\$pc_reads_host\t\$reads_virus\t\$pc_reads_virus\t\$unmapped_reads\t\$pc_unmapped\t\$coverage_depth\t\$pc_genome_greater_10x\t\$pc_Ns\t\$variants_in_consensus\t\$variants_with_effect\t\$number_unambiguous_bases\t\$number_Ns\t\$read_length\t\$analysis_date\t\$cov_HA\t\$cov_MP\t\$cov_NA\t\$cov_NP\t\$cov_NS\t\$cov_PA\t\$cov_PB1\t\$cov_PB2\t\$cov10x_HA\t\$cov10x_MP\t\$cov10x_NA\t\$cov10x_NP\t\$cov10x_NS\t\$cov10x_PA\t\$cov10x_PB1\t\$cov10x_PB2\t\$perNs_HA\t\$perNs_MP\t\$perNs_NA\t\$perNs_NP\t\$perNs_NS\t\$perNs_PA\t\$perNs_PB1\t\$perNs_PB2\t\$variants_HA\t\$variants_MP\t\$variants_NA\t\$variants_NP\t\$variants_NS\t\$variants_PA\t\$variants_PB1\t\$variants_PB2\" >> summary_stats_\$(date \"+%Y%m%d\").tab
-    echo -e \"-----Statistics for \$in correctly added into summary_stats_\$(date \"+%Y%m%d\").tab-----\n\"
-    unset gene_coverage coverages_10x per_Ns variants
-  done < ../samples_id.txt
-" > _05_create_summary_stats.sh
+  if [ \${#ns_values[@]} -gt 0 ]; then
+    total_ns=0
+    for ns in \"\${ns_values[@]}\"; do
+      total_ns=\$(echo \"\$total_ns + \$ns\" | bc)
+    done
+    pc_Ns=\$(printf \"%.2f\" \"\$(echo \"\$total_ns / \${#ns_values[@]}\" | bc -l)\")
+  else
+    pc_Ns=\"NA\"
+  fi
 
-# Run _05_create_summary_stats.sh
-echo "srun --partition middle_idx --chdir ${scratch_dir} --output logs/SUMMARY_STATS.%j.log --job-name SUMMARY_STATS --time 01:00:00 bash ${scratch_dir}/_05_create_summary_stats.sh &" > _05_run_create_summary_stats.sh
+  analysis_date=\$(date \"+%Y-%m-%d\")
+  flu_type=\$(awk -F '\t' -v sample=\"\$in\" '\$1 == sample {print \$5; exit}' ../04-irma/irma_stats_flu.txt | cut -d \"_\" -f 1)
+  flu_subtype=\$(awk -F '\t' -v sample=\"\$in\" '\$1 == sample {split(\$5, parts, \"_\"); if (length(parts) >= 3) print parts[2] parts[3]; exit}' ../04-irma/irma_stats_flu.txt)
+  coverage_depth=\$(printf \"%s\\n\" \"\${coverage_medians[@]}\" | sort -n | awk '{a[NR]=\$1} END {print (NR%2==1)? a[(NR+1)/2] : (a[NR/2] + a[NR/2+1]) / 2}')
+  variants_in_consensus=\$(printf \"%s\\n\" \"\${variants_consensus[@]}\" | awk '{sum+=\$1} END{print sum}')
+  variants_with_effect=\$(awk -F, -v sample=\"\$in\" '\$1 == sample && \$8 == \"consensus\" && \$14 == \"missense_variant\" {count++} END {print count+0}' variants_long_table.csv)
+  pc_genome_greater_10x=\$(printf \"%s\\n\" \"\${pc10x[@]}\" | sort -n | awk '{sum+=\$1} END {printf \"%.2f\", (NR ? sum/NR : 0)}')
+  virus_sequence=\$(awk -v sample=\"\${in}\" '\$1 == sample {ref = ref ? ref \",\" \$4 : \$4} END {if (ref) print ref}' ../06-variant-calling/sample_type_ref.txt)
+  total_reads=\$(grep \"\\\"total_reads\\\"\" ../02-preprocessing/\${in}/\${in}_fastp.json | head -n1 | cut -d \":\" -f2 | sed \"s/,//g\")
+  reads_host=\$(awk -v sample=\"\${in}_run1\" '\$1 == sample {print int(\$2)}' ../../*_TAXPROFILER/multiqc/multiqc_data/samtools_alignment_plot.txt)
+  pc_reads_host=\$(awk -v v1=\$total_reads -v v2=\$reads_host 'BEGIN {printf \"%.2f\", (v2*100)/v1}')
+  reads_virus=\$(awk -F\"\t\" -v id=\"\$in\" '\$1 == id {print \$3}' ../04-irma/irma_stats_flu.txt)
+  pc_reads_virus=\$(awk -v v1=\$reads_virus -v v2=\$total_reads 'BEGIN {if (v2 > 0) printf \"%.2f\", (v1 / v2) * 100; else print \"NA\"}')
+  unmapped_reads=\$((total_reads - (reads_host+reads_virus)))
+  pc_unmapped=\$(awk -v v1=\$total_reads -v v2=\$unmapped_reads  'BEGIN {printf \"%.2f\", (v2/v1)*100}')
+  qc_filtered=\$(grep \"\\\"total_reads\\\"\" ../02-preprocessing/\${in}/\${in}_fastp.json | head -n2 | tail -n1 | cut -d \":\" -f2 | sed \"s/,//g\")
+  read_length=\$(unzip -p ../03-procQC/\${in}/\${in}_R1_filtered_fastqc.zip */fastqc_data.txt | grep \"Sequence length\" | cut -d \"-\" -f2)
+  number_unambiguous_bases=\$(awk -F \"\t\" -v id=\"\$in\" '\$1 == id {print \$2}' qc_metrics.tsv)
+  number_Ns=\$(awk -F \"\t\" -v id=\"\$in\" '\$1 == id {print \$3}' qc_metrics.tsv)
+  if grep -q \$in ../05-nextclade/nextclade_combined.csv; then
+    clade=\$(awk -F \";\" -v sample="\$in" '\$2 ~ sample {print \$3}' ../05-nextclade/nextclade_combined.csv)
+else
+  clade=\$(awk -F \";\" -v sample=\"\$(echo \$in | sed \"s/-/\\//g\")_HA\" '\$2 == sample {print \$3}' ../05-nextclade/nextclade_combined.csv)
+fi
+  clade_assignment_date=\$(cat ../05-nextclade/\${flu_type}*/nextclade.json | awk -F'\"' '/createdAt/ {print \$4}' | cut -d 'T' -f 1 | tr -d '-' | head -n 1 | sed 's/\(....\)\(..\)\(..\)/\1-\2-\3/')
+  clade_assignment_software_database_version=\$(cat ../05-nextclade/logs/NEXTCLADE_RUN_\${flu_type}_\$(echo \${flu_subtype} | cut -d \"N\" -f 1)*.log | grep -oE '[0-9]{4}-[0-9]{2}-[0-9]{2}--[0-9]{2}-[0-9]{2}-[0-9]{2}Z' | head -n 1)
+  cov_HA=\${gene_coverage[HA]}
+  cov_MP=\${gene_coverage[MP]}
+  cov_NA=\${gene_coverage[NA]}
+  cov_NP=\${gene_coverage[NP]}
+  cov_NS=\${gene_coverage[NS]}
+  cov_PA=\${gene_coverage[PA]}
+  cov_PB1=\${gene_coverage[PB1]}
+  cov_PB2=\${gene_coverage[PB2]}
+  cov10x_HA=\${coverages_10x[HA]}
+  cov10x_MP=\${coverages_10x[MP]}
+  cov10x_NA=\${coverages_10x[NA]}
+  cov10x_NP=\${coverages_10x[NP]}
+  cov10x_NS=\${coverages_10x[NS]}
+  cov10x_PA=\${coverages_10x[PA]}
+  cov10x_PB1=\${coverages_10x[PB1]}
+  cov10x_PB2=\${coverages_10x[PB2]}
+  perNs_HA=\${per_Ns[HA]}
+  perNs_MP=\${per_Ns[MP]}
+  perNs_NA=\${per_Ns[NA]}
+  perNs_NP=\${per_Ns[NP]}
+  perNs_NS=\${per_Ns[NS]}
+  perNs_PA=\${per_Ns[PA]}
+  perNs_PB1=\${per_Ns[PB1]}
+  perNs_PB2=\${per_Ns[PB2]}
+  variants_HA=\${variants[HA]}
+  variants_MP=\${variants[MP]}
+  variants_NA=\${variants[NA]}
+  variants_NP=\${variants[NP]}
+  variants_NS=\${variants[NS]}
+  variants_PA=\${variants[PA]}
+  variants_PB1=\${variants[PB1]}
+  variants_PB2=\${variants[PB2]}
+
+  echo -e \"\${in}\t\$virus_sequence\t\$flu_type\t\$flu_subtype\t\$clade\t\$clade_assignment_date\t\$clade_assignment_software_database_version\t\$total_reads\t\$qc_filtered\t\$reads_host\t\$pc_reads_host\t\$reads_virus\t\$pc_reads_virus\t\$unmapped_reads\t\$pc_unmapped\t\$coverage_depth\t\$pc_genome_greater_10x\t\$pc_Ns\t\$variants_in_consensus\t\$variants_with_effect\t\$number_unambiguous_bases\t\$number_Ns\t\$read_length\t\$analysis_date\t\$cov_HA\t\$cov_MP\t\$cov_NA\t\$cov_NP\t\$cov_NS\t\$cov_PA\t\$cov_PB1\t\$cov_PB2\t\$cov10x_HA\t\$cov10x_MP\t\$cov10x_NA\t\$cov10x_NP\t\$cov10x_NS\t\$cov10x_PA\t\$cov10x_PB1\t\$cov10x_PB2\t\$perNs_HA\t\$perNs_MP\t\$perNs_NA\t\$perNs_NP\t\$perNs_NS\t\$perNs_PA\t\$perNs_PB1\t\$perNs_PB2\t\$variants_HA\t\$variants_MP\t\$variants_NA\t\$variants_NP\t\$variants_NS\t\$variants_PA\t\$variants_PB1\t\$variants_PB2\" > tmp_\${in}.tab
+  echo -e \"-----Statistics for \$in correctly added into tmp_\${in}.tab-----\n\"
+  unset gene_coverage coverages_10x per_Ns variants
+
+" > aux_create_summary_stats.sh
+
+# Batch job. Generates 1 task per sample, but with a concurrency of 50 max (Defined by module division in --array)
+echo "#!/usr/bin/env bash
+#SBATCH --job-name=summary_stats
+#SBATCH --cpus-per-task=1
+#SBATCH --mem=1G
+#SBATCH --time=00:30:00
+#SBATCH --array=1-$(wc -l < ../samples_id.txt)%50
+#SBATCH --partition=short_idx
+#SBATCH --output=logs/SUMMARY_STATS.$(date "+%Y%m%d").log
+#SBATCH --chdir=$scratch_dir
+
+# Get sample ID for this task
+in=\$(sed -n \"\${SLURM_ARRAY_TASK_ID}p\" ../samples_id.txt)
+
+# Run worker
+bash aux_create_summary_stats.sh \"\$in\"
+" > _05_create_summary_stats.sbatch
+
+echo "jobid=\$(sbatch --parsable _05_create_summary_stats.sbatch)
+# Clean after batch job - merge stats and remove tmp files
+sbatch --dependency=afterok:\$jobid <<EOF
+#!/usr/bin/env bash
+#SBATCH --job-name=merge_stats
+#SBATCH --output=logs/MERGE_STATS.$(date "+%Y%m%d").log
+#SBATCH --chdir=$scratch_dir
+HEADER=\"sample\tVirussequence\tflu_type\tflu_subtype\tclade\tclade_assignment_date\tclade_assignment_software_database_version\ttotalreads\tqc_filtered_reads\treads_host\t%readshost\treads_virus\t%readsvirus\tunmapped_reads\t%unmappedreads\tmedianDPcoveragevirus\tCoverage>10x(%)\t%Ns10x\tVariantsinconsensusx10\tMissenseVariants\tTotal_Unambiguous_Bases\tTotal_Ns_count\tread_length\tanalysis_date\tmedianDPcoveragevirusHA\tmedianDPcoveragevirusMP\tmedianDPcoveragevirusNA\tmedianDPcoveragevirusNP\tmedianDPcoveragevirusNS\tmedianDPcoveragevirusPA\tmedianDPcoveragevirusPB1\tmedianDPcoveragevirusPB2\tCoverage>10xHA(%)\tCoverage>10xMP(%)\tCoverage>10xNA(%)\tCoverage>10xNP(%)\tCoverage>10xNS(%)\tCoverage>10xPA(%)\tCoverage>10xPB1(%)\tCoverage>10xPB2(%)\tperNs_HA\tperNs_MP\tperNs_NA\tperNs_NP\tperNs_NS\tperNs_PA\tperNs_PB1\tperNs_PB2\tvariants_HA\tvariants_MP\tvariants_NA\tvariants_NP\tvariants_NS\tvariants_PA\tvariants_PB1\tvariants_PB2\"
+echo -e \${HEADER} > summary_stats_\$(date \"+%Y%m%d\").tab
+cat tmp_*.tab >> summary_stats_\$(date \"+%Y%m%d\").tab
+rm tmp_*.tab
+EOF
+" > _05_run_create_summary_stats.sh


### PR DESCRIPTION
<!--
# bu-isciii tools pull request

Based on nf-core/viralrecon pull request template

Fill in the appropriate checklist below and delete whatever is not relevant.

PRs should be made against the develop of hotfix branch, unless you're preparing a software release.
-->
## Description of the issue

While running IRMA, I noticed that the 99-stats step is a very slow one, taking up to an hour or 2 if there are enough samples. We identified the choking point to be step 05, the creation of the summary stats, since this calls a bash script that repeats the same step for each of the samples.

I have made the script a sbatch script so that it runs in parallel for each sample, up to a limit of 50 concurrent tasks (The tasks are actually quite small, this limit is to not overwhelm the HPC). 

The output has been tested against the original output from `SRVCNM1484_20251028_GENOMEFLU69_pacopozo_S/` (47 samples). It reduces drastically the speed (15 min vs a couple seconds) and the output is identical.

When the new release is done, we will need to update this in the wiki: https://github.com/BU-ISCIII/BU-ISCIII/wiki/IRMA-service#99-stats.

Issue for the wiki [here](https://github.com/BU-ISCIII/BU-ISCIII/issues/140)

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`black and flake8`).
- [x] `CHANGELOG.md` is updated.
