### PR TITLE
Fixing AF filtering and results symlinks in wgstrio template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fixed wgstrio 99-stats lablog to prevent OutOfMemoryError on WGS samples. [#654](https://github.com/BU-ISCIII/buisciii-tools/pull/654)
 - Fixed wgstrio folder template structure [#655](https://github.com/BU-ISCIII/buisciii-tools/pull/655)
 - Updated recommended Nextflow version in taxprofiler lablog [#655](https://github.com/BU-ISCIII/buisciii-tools/pull/655)
+- Fixing AF filtering and results symlinks in wgstrio template [#659](https://github.com/BU-ISCIII/buisciii-tools/pull/659)
 
 ### Modules
 

--- a/buisciii/templates/wgstrio/ANALYSIS/ANALYSIS01_GENOME/03-annotation/lablog
+++ b/buisciii/templates/wgstrio/ANALYSIS/ANALYSIS01_GENOME/03-annotation/lablog
@@ -48,7 +48,7 @@ echo "srun --partition short_idx --time 2:00:00 --chdir ${scratch_dir} --output 
 
 # 6. Filter variants_annot_all.tab
 
-echo "awk 'NR>1 && \$58 > 0.001 {print \$0}' variants_annot_all.tab > ./variants_annot_filterAF.tab" >> aux_03_awk.sh
+echo "awk 'NR>1 && \$61 > 0.001 {print \$0}' variants_annot_all.tab > ./variants_annot_filterAF.tab" >> aux_03_awk.sh
 
 echo "cat header_vep_final_annot.txt variants_annot_filterAF.tab > variants_annot_filterAF_head.tab" >> aux_03_awk.sh
 

--- a/buisciii/templates/wgstrio/RESULTS/lablog_wgstrio_results
+++ b/buisciii/templates/wgstrio/RESULTS/lablog_wgstrio_results
@@ -4,8 +4,8 @@ cd $(date '+%Y%m%d')_entrega01
 #Create symbolic links depending on the analysis
 #Individual files
 
-ln -s ../../ANALYSIS/*ANALYSIS01_EXOME/99-stats/hsMetrics_all.out mapping_metrics.csv
-ln -s ../../ANALYSIS/*ANALYSIS01_EXOME/01-sarek/multiqc/multiqc_report.html .
-ln -s ../../ANALYSIS/*ANALYSIS01_EXOME/03-annotation/variants_*filterAF*.tab .
+ln -s ../../ANALYSIS/*ANALYSIS01_GENOME/99-stats/hsMetrics_all.out mapping_metrics.csv
+ln -s ../../ANALYSIS/*ANALYSIS01_GENOME/01-sarek/multiqc/multiqc_report.html .
+ln -s ../../ANALYSIS/*ANALYSIS01_GENOME/03-annotation/variants_*filterAF*.tab .
 
-ln -s ../../../ANALYSIS/*ANALYSIS01_EXOME/03-annotation/filter_inheritance annotation_tables .
+ln -s ../../ANALYSIS/*ANALYSIS01_GENOME/03-annotation/filter_inheritance annotation_tables


### PR DESCRIPTION
<!--
# bu-isciii tools pull request

Based on nf-core/viralrecon pull request template

Fill in the appropriate checklist below and delete whatever is not relevant.

PRs should be made against the develop of hotfix branch, unless you're preparing a software release.
-->
This PR addresses two fixes in the **wgstrio** service template:

Fix broken symlinks in the `lablog_wgstrio_results` script. 
Fix the filtering column used for AF in `aux_03_awk.sh `during the **03-annotation** step.

Resolved Issues
- Issue #657 
- Issue #658 

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`black and flake8`).
- If a new tamplate was added make sure:
    - [ ] Template's schema is added in `templates/services.json`.
    - [ ] Template's pipeline's documentation in `assets/reports/md/template.md` is added.
    - [ ] Results Documentation in `assets/reports/results/template.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
- [ ] If you know a new user was added to the SFTP, make sure you added it to `templates/sftp_user.json`
