### PR TITLE
Fixed column selection, now selects MAX_AF in wgstrio template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fixed wgstrio folder template structure [#655](https://github.com/BU-ISCIII/buisciii-tools/pull/655)
 - Updated recommended Nextflow version in taxprofiler lablog [#655](https://github.com/BU-ISCIII/buisciii-tools/pull/655)
 - Fixing AF filtering and results symlinks in wgstrio template [#659](https://github.com/BU-ISCIII/buisciii-tools/pull/659)
+- Fixed column selection, now selects MAX_AF in wgstrio template [#660](https://github.com/BU-ISCIII/buisciii-tools/pull/660)
 
 ### Modules
 

--- a/buisciii/templates/wgstrio/ANALYSIS/ANALYSIS01_GENOME/03-annotation/lablog
+++ b/buisciii/templates/wgstrio/ANALYSIS/ANALYSIS01_GENOME/03-annotation/lablog
@@ -48,7 +48,9 @@ echo "srun --partition short_idx --time 2:00:00 --chdir ${scratch_dir} --output 
 
 # 6. Filter variants_annot_all.tab
 
-echo "awk 'NR>1 && \$61 > 0.001 {print \$0}' variants_annot_all.tab > ./variants_annot_filterAF.tab" >> aux_03_awk.sh
+echo "max_af_col=\$( head -n 1 variants_annot_all.tab | tr '\t' '\n' | nl -v0 | grep -i 'MAX_AF$' | awk '{print $1 + 1}' )" >> aux_03_awk.sh
+
+echo "awk -v max_af_col=\$max_af_col 'NR>1 && \$max_af_col > 0.001 {print \$0}' variants_annot_all.tab > ./variants_annot_filterAF.tab" >> aux_03_awk.sh
 
 echo "cat header_vep_final_annot.txt variants_annot_filterAF.tab > variants_annot_filterAF_head.tab" >> aux_03_awk.sh
 


### PR DESCRIPTION
<!--
# bu-isciii tools pull request

Based on nf-core/viralrecon pull request template

Fill in the appropriate checklist below and delete whatever is not relevant.

PRs should be made against the develop of hotfix branch, unless you're preparing a software release.
-->
## Description of the PR
Small PR correcting the filtering at the annotation step - Now using MAX_AF and retrieving the column index dynamically


## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`black and flake8`).
- If a new tamplate was added make sure:
    - [ ] Template's schema is added in `templates/services.json`.
    - [ ] Template's pipeline's documentation in `assets/reports/md/template.md` is added.
    - [ ] Results Documentation in `assets/reports/results/template.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
- [ ] If you know a new user was added to the SFTP, make sure you added it to `templates/sftp_user.json`
