### PR TITLE
Fix: handled wkhtmltopdf errors in bioinfo-doc PDF generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Updated recommended Nextflow version in taxprofiler lablog [#655](https://github.com/BU-ISCIII/buisciii-tools/pull/655)
 - Fixing AF filtering and results symlinks in wgstrio template [#659](https://github.com/BU-ISCIII/buisciii-tools/pull/659)
 - Fixed column selection, now selects MAX_AF in wgstrio template [#660](https://github.com/BU-ISCIII/buisciii-tools/pull/660)
+- Fixed QSslSocket and wkhtmltopdf errors in bioinfo-doc PDF generation [#662](https://github.com/BU-ISCIII/buisciii-tools/pull/662)
 
 ### Modules
 

--- a/buisciii/assets/reports/md/sarek.md
+++ b/buisciii/assets/reports/md/sarek.md
@@ -1223,7 +1223,6 @@ You can find information on how to interpret results from VEP toolkit [here](htt
 
 [![GitHub release](https://img.shields.io/github/release/exomiser/Exomiser.svg)](https://github.com/exomiser/Exomiser/releases)
 [![CircleCI](https://circleci.com/gh/exomiser/Exomiser/tree/development.svg?style=shield)](https://circleci.com/gh/exomiser/Exomiser/tree/development)
-[![Codacy Badge](https://api.codacy.com/project/badge/Grade/b518a9448b5b4889a40b3dc660ef585a)](https://www.codacy.com/app/monarch-initiative/Exomiser?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=exomiser/Exomiser&amp;utm_campaign=Badge_Grade)
 [![Documentation](https://readthedocs.org/projects/exomiser/badge/?version=latest)](http://exomiser.readthedocs.io/en/latest)
 #### Overview:
 

--- a/buisciii/bioinfo_doc.py
+++ b/buisciii/bioinfo_doc.py
@@ -557,10 +557,9 @@ class BioinfoDoc:
             log.info(f"PDF file created successfully: {pdf_file}")
         except OSError as e:
             if "QSslSocket" in repr(e):
-                log.info(
+                log.warning(
                     f"QSslSocket error occurred while converting {html_file} to {pdf_file}. Ignoring..."
                 )
-                pass
             else:
                 stderr.print(
                     "[red]Unable to convert to PDF! Check logs for more details"

--- a/buisciii/bioinfo_doc.py
+++ b/buisciii/bioinfo_doc.py
@@ -555,11 +555,15 @@ class BioinfoDoc:
                 html_file, output_path=pdf_file, configuration=self.config_pdfkit
             )
             log.info(f"PDF file created successfully: {pdf_file}")
-        except OSError:
-            stderr.print("[red]Unable to convert to PDF!")
-            log.error("Unable to convert to PDF")
-            raise
-        return
+        except OSError as e:
+            if "QSslSocket" in repr(e):
+                log.info(f"QSslSocket error occurred while converting {html_file} to {pdf_file}. Ignoring...")
+                pass
+            else:
+                stderr.print("[red]Unable to convert to PDF! Check logs for more details")
+                log.error(f"Unable to convert to PDF. Error: \n{e}")
+                raise
+        return pdf_file
 
     def generate_documentation_files(self, type):
         """

--- a/buisciii/bioinfo_doc.py
+++ b/buisciii/bioinfo_doc.py
@@ -557,10 +557,14 @@ class BioinfoDoc:
             log.info(f"PDF file created successfully: {pdf_file}")
         except OSError as e:
             if "QSslSocket" in repr(e):
-                log.info(f"QSslSocket error occurred while converting {html_file} to {pdf_file}. Ignoring...")
+                log.info(
+                    f"QSslSocket error occurred while converting {html_file} to {pdf_file}. Ignoring..."
+                )
                 pass
             else:
-                stderr.print("[red]Unable to convert to PDF! Check logs for more details")
+                stderr.print(
+                    "[red]Unable to convert to PDF! Check logs for more details"
+                )
                 log.error(f"Unable to convert to PDF. Error: \n{e}")
                 raise
         return pdf_file


### PR DESCRIPTION
## Description

This PR fixes PDF generation failures in `bioinfo-doc` caused by wkhtmltopdf errors. 

## Changes
Modified the `convert_to_pdf()` function in `buisciii/bioinfo_doc.py` to handle non-critical errors:
  - Catches `QSslSocket` errors specifically and logs them as info (not errors)
  - Allows workflow to continue when non-critical errors occur
  - Still raises exception for genuine failures 
  - Always returns `pdf_file` path to allow downstream steps to proceed (email delivery).

Removed broken Codacy badge on `sarek.md` to avoid html to pdf error. 

## Why this approach?
This is a fix makes the tool resilient to external failures:
- External resources can break at any time (URL changes, servers down, API changes)
- Network issues are often temporary and shouldn't block deliveries
- The warnings are informational, not fatal errors

Even if all current external resources are fixed, future templates or temporary network issues could trigger similar problems.

Fixes #661 

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`black and flake8`).
- If a new tamplate was added make sure:
    - [ ] Template's schema is added in `templates/services.json`.
    - [ ] Template's pipeline's documentation in `assets/reports/md/template.md` is added.
    - [ ] Results Documentation in `assets/reports/results/template.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
- [ ] If you know a new user was added to the SFTP, make sure you added it to `templates/sftp_user.json`
