### PR TITLE
Add numeric sample ID validation for samplesheet.csv in assembly lablog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fixed QSslSocket and wkhtmltopdf errors in bioinfo-doc PDF generation [#662](https://github.com/BU-ISCIII/buisciii-tools/pull/662)
 - Make VEP header generation dynamic and remove static template dependency [#664] (https://github.com/BU-ISCIII/buisciii-tools/pull/664)
 - Updated blast database with new assemblies downloaded in March 2026 [#665](https://github.com/BU-ISCIII/buisciii-tools/pull/665)
+- Added numeric sample ID validation for samplesheet.csv in assembly lablog [#667](https://github.com/BU-ISCIII/buisciii-tools/pull/667)
 
 ### Modules
 

--- a/buisciii/templates/assembly/ANALYSIS/ANALYSIS01_ASSEMBLY/lablog
+++ b/buisciii/templates/assembly/ANALYSIS/ANALYSIS01_ASSEMBLY/lablog
@@ -81,12 +81,17 @@ ln -s ../samples_id.txt .
 
 echo "ID,R1,R2,LongFastQ,Fast5,GenomeSize" > samplesheet.csv
 cat samples_id.txt | while read in; do
+    if [[ "$in" =~ ^[0-9]+$ ]]; then
+        id="${in}_S"
+    else
+        id="${in}"
+    fi
     if [ "$ASSEMBLY_MODE" == "short" ]; then
-        echo "${in},00-reads/${in}_R1.fastq.gz,00-reads/${in}_R2.fastq.gz,NA,NA,NA";
+        echo "${id},00-reads/${in}_R1.fastq.gz,00-reads/${in}_R2.fastq.gz,NA,NA,NA";
     elif [ "$ASSEMBLY_MODE" == "long" ]; then
-        echo "${in},NA,NA,00-reads/${in}.fastq.gz,NA,NA";
+        echo "${id},NA,NA,00-reads/${in}.fastq.gz,NA,NA";
     elif [ "$ASSEMBLY_MODE" == "hybrid" ]; then
-        echo "${in},00-reads/${in}_R1.fastq.gz,00-reads/${in}_R2.fastq.gz,00-reads/${in}.fastq.gz,NA,NA";
+        echo "${id},00-reads/${in}_R1.fastq.gz,00-reads/${in}_R2.fastq.gz,00-reads/${in}.fastq.gz,NA,NA";
     else
         echo "Format not recognized for the sample : ${in}.";
     fi


### PR DESCRIPTION
## Description
When sample names in `samples_id.txt` are purely numeric, the generated `samplesheet.csv` writes the ID field as an integer. `nf-core/bacass` interprets these as integers instead of strings, causing a validation error.

## Changes
Added a validation in the assembly lablog that detects purely numeric sample IDs and appends `_S` suffix to them before writing the samplesheet.csv. 
Non-numeric IDs remain unchanged.

## Related issue
Closes #666

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`black and flake8`).
- If a new tamplate was added make sure:
    - [ ] Template's schema is added in `templates/services.json`.
    - [ ] Template's pipeline's documentation in `assets/reports/md/template.md` is added.
    - [ ] Results Documentation in `assets/reports/results/template.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
- [ ] If you know a new user was added to the SFTP, make sure you added it to `templates/sftp_user.json`
