### PR TITLE
Updated location for the blast database to refgenie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Make VEP header generation dynamic and remove static template dependency [#664] (https://github.com/BU-ISCIII/buisciii-tools/pull/664)
 - Updated blast database with new assemblies downloaded in March 2026 [#665](https://github.com/BU-ISCIII/buisciii-tools/pull/665)
 - Added numeric sample ID validation for samplesheet.csv in assembly lablog [#667](https://github.com/BU-ISCIII/buisciii-tools/pull/667)
+- Updated blast database location to refgenie directory [#669](https://github.com/BU-ISCIII/buisciii-tools/pull/669)
 
 ### Modules
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Make VEP header generation dynamic and remove static template dependency [#664] (https://github.com/BU-ISCIII/buisciii-tools/pull/664)
 - Updated blast database with new assemblies downloaded in March 2026 [#665](https://github.com/BU-ISCIII/buisciii-tools/pull/665)
 - Added numeric sample ID validation for samplesheet.csv in assembly lablog [#667](https://github.com/BU-ISCIII/buisciii-tools/pull/667)
-- Updated blast database location to refgenie directory [#669](https://github.com/BU-ISCIII/buisciii-tools/pull/669)
+- Updated blast database location to refgenie directory [#683](https://github.com/BU-ISCIII/buisciii-tools/pull/683)
 
 ### Modules
 

--- a/buisciii/templates/blast_nt/ANALYSIS/ANALYSIS02_BLAST/lablog
+++ b/buisciii/templates/blast_nt/ANALYSIS/ANALYSIS02_BLAST/lablog
@@ -9,7 +9,7 @@ LOCATION=../*/*/assembly/*/*
 # /data/ucct/bi/references/BLAST_dbs/nt_20211025/nt
 # /data/ucct/bi/references/BLAST_dbs/viral_ncbi/viral_genomes_ncbi
 # /data/ucct/bi/references/BLAST_dbs/viral_assemblies_20250718/ncbi_assemblies_20250718
-BLAST_DATABASE="/data/ucct/bi/references/BLAST_dbs/virus_assemblies_nt_20260318/viral_assembly_ncbi_nt"
+BLAST_DATABASE="/data/ucct/bi/references/refgenie/alias/BLAST/viral_assemblies/v20260318/viral_assembly_ncbi_nt"
 
 # if there are scaffolds, uncompress the scaffolds in its dir (zcat for decompression)
 # if there contigs and no scaffolds, uncompress the contigs as scaffolds in its dir
@@ -29,7 +29,7 @@ cat ../samples_id.txt | while read in; do
 done 
 
 # NOTE3: change the -query flag to meet your requirements
-cat ../samples_id.txt | xargs -I %% echo "srun --chdir ${scratch_dir} --partition middle_idx --mem 200G --time 48:00:00 --cpus-per-task 10 --output logs/BLASTN_%%_%j.log --job-name BLASTN_%% singularity exec -B ${scratch_dir}/../../ -B /data/ucct/bi/references/BLAST_dbs/virus_assemblies_nt_20260318/ /data/ucct/bi/pipelines/singularity-images/blast:2.17.0--h66d330f_0 blastn -num_threads 10 -db ${BLAST_DATABASE} -query ${scratch_dir}/%%/%%.scaffolds.fa -out ${scratch_dir}/%%/%%_blast.tsv -outfmt '6 qseqid stitle qaccver saccver pident length mismatch gaps qstart qend sstart send evalue bitscore slen qlen qcovs' &" > _01_blast.sh
+cat ../samples_id.txt | xargs -I %% echo "srun --chdir ${scratch_dir} --partition middle_idx --mem 200G --time 48:00:00 --cpus-per-task 10 --output logs/BLASTN_%%_%j.log --job-name BLASTN_%% singularity exec -B ${scratch_dir}/../../ -B /data/ucct/bi/references/refgenie/alias/BLAST/viral_assemblies/v20260318/ /data/ucct/bi/pipelines/singularity-images/blast:2.17.0--h66d330f_0 blastn -num_threads 10 -db ${BLAST_DATABASE} -query ${scratch_dir}/%%/%%.scaffolds.fa -out ${scratch_dir}/%%/%%_blast.tsv -outfmt '6 qseqid stitle qaccver saccver pident length mismatch gaps qstart qend sstart send evalue bitscore slen qlen qcovs' &" > _01_blast.sh
 
 # Filtering criteria:
     # %refCovered > 0.7


### PR DESCRIPTION
The new location to store blast databases is /data/ucct/bi/references/refgenie/ right now
This PR updates the correct path to the new location of the latest NCBI virus refseq/genbank database used for BLAST, downloaded on 2026/03/18.  

<!--
# bu-isciii tools pull request

Based on nf-core/viralrecon pull request template

Fill in the appropriate checklist below and delete whatever is not relevant.

PRs should be made against the develop of hotfix branch, unless you're preparing a software release.
-->

## PR checklist

- [X] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`black and flake8`).
- If a new tamplate was added make sure:
    - [ ] Template's schema is added in `templates/services.json`.
    - [ ] Template's pipeline's documentation in `assets/reports/md/template.md` is added.
    - [ ] Results Documentation in `assets/reports/results/template.md` is updated.
- [X] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
- [ ] If you know a new user was added to the SFTP, make sure you added it to `templates/sftp_user.json`
