### PR TITLE
Add trim_poly_x fastp arg to assembly config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,14 +26,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fixed column selection, now selects MAX_AF in wgstrio template [#660](https://github.com/BU-ISCIII/buisciii-tools/pull/660)
 - Fixed QSslSocket and wkhtmltopdf errors in bioinfo-doc PDF generation [#662](https://github.com/BU-ISCIII/buisciii-tools/pull/662)
 - Make VEP header generation dynamic and remove static template dependency [#664] (https://github.com/BU-ISCIII/buisciii-tools/pull/664)
-<<<<<<< HEAD
 - Updated blast database with new assemblies downloaded in March 2026 [#665](https://github.com/BU-ISCIII/buisciii-tools/pull/665)
 - Added numeric sample ID validation for samplesheet.csv in assembly lablog [#667](https://github.com/BU-ISCIII/buisciii-tools/pull/667)
 - Updated `wgstrio`, `exometrio` and `rnaseq` templates to generate OmicsExplorer-compatible outputs. [#668](https://github.com/BU-ISCIII/buisciii-tools/pull/668)
 - Updated blast database location to refgenie directory [#683](https://github.com/BU-ISCIII/buisciii-tools/pull/683)
-=======
 - Add trim_poly_x fastp arg to assembly config [#685](https://github.com/BU-ISCIII/buisciii-tools/pull/685)
->>>>>>> 4519a1c (Updated CHANGELOG.md)
 
 ### Modules
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,10 +26,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fixed column selection, now selects MAX_AF in wgstrio template [#660](https://github.com/BU-ISCIII/buisciii-tools/pull/660)
 - Fixed QSslSocket and wkhtmltopdf errors in bioinfo-doc PDF generation [#662](https://github.com/BU-ISCIII/buisciii-tools/pull/662)
 - Make VEP header generation dynamic and remove static template dependency [#664] (https://github.com/BU-ISCIII/buisciii-tools/pull/664)
+<<<<<<< HEAD
 - Updated blast database with new assemblies downloaded in March 2026 [#665](https://github.com/BU-ISCIII/buisciii-tools/pull/665)
 - Added numeric sample ID validation for samplesheet.csv in assembly lablog [#667](https://github.com/BU-ISCIII/buisciii-tools/pull/667)
 - Updated `wgstrio`, `exometrio` and `rnaseq` templates to generate OmicsExplorer-compatible outputs. [#668](https://github.com/BU-ISCIII/buisciii-tools/pull/668)
 - Updated blast database location to refgenie directory [#683](https://github.com/BU-ISCIII/buisciii-tools/pull/683)
+=======
+- Add trim_poly_x fastp arg to assembly config [#685](https://github.com/BU-ISCIII/buisciii-tools/pull/685)
+>>>>>>> 4519a1c (Updated CHANGELOG.md)
 
 ### Modules
 

--- a/buisciii/templates/assembly/ANALYSIS/ANALYSIS01_ASSEMBLY/lablog
+++ b/buisciii/templates/assembly/ANALYSIS/ANALYSIS01_ASSEMBLY/lablog
@@ -121,7 +121,6 @@ nextflow run /data/ucct/bi/pipelines/nf-core-bacass/nf-core-bacass-2.5.0/main.nf
         --assembler ${ASSEMBLER} \\
         --skip_polish true \\
         --save_trimmed ${SAVETRIMMED} \\
-        --fastp_args '--qualified_quality_phred 20 --cut_mean_quality 20' \\
         --skip_kraken2 true \\
         --skip_kmerfinder false \\
         --kmerfinderdb /data/ucct/bi/references/kmerfinder/latest/bacteria \\

--- a/buisciii/templates/assembly/DOC/hpc_slurm_assembly.config
+++ b/buisciii/templates/assembly/DOC/hpc_slurm_assembly.config
@@ -53,9 +53,11 @@ process {
 		    ]
         ]
 	}
-	withName: '.*:.*:FASTQ_TRIM_FASTP_FASTQC:FASTP' {
-		publishDir = [
-			[
+    withName: '.*:.*:FASTQ_TRIM_FASTP_FASTQC:FASTP' {
+        ext.args = '--trim_poly_x --qualified_quality_phred 20 --cut_mean_quality 20'
+
+        publishDir = [
+            [
                 path: { "${params.outdir}/01-processing/fastp" },
                 mode: params.publish_dir_mode,
                 enabled: params.save_trimmed
@@ -70,8 +72,8 @@ process {
                 mode: params.publish_dir_mode,
                 pattern: "*.log"
             ]
-		]
-	}
+        ]
+    }
 	withName: '.*:.*:FASTQ_TRIM_FASTP_FASTQC:FASTQC_TRIM' {
 		maxRetries = 2
         	memory = {12.GB * task.attempt}
@@ -88,10 +90,6 @@ process {
             ]
 		]
 	}
-
-    withName: 'FASTP' {
-            ext.args = '--trim_poly_x --qualified_quality_phred 20 --cut_mean_quality 20'
-        }
 
     withName: 'NANOPLOT' {
         publishDir = [

--- a/buisciii/templates/assembly/DOC/hpc_slurm_assembly.config
+++ b/buisciii/templates/assembly/DOC/hpc_slurm_assembly.config
@@ -88,6 +88,11 @@ process {
             ]
 		]
 	}
+
+    withName: 'FASTP' {
+            ext.args = '--trim_poly_x --qualified_quality_phred 20 --cut_mean_quality 20'
+        }
+
     withName: 'NANOPLOT' {
         publishDir = [
             path: { "${params.outdir}/01-processing/nanoplot" },


### PR DESCRIPTION
<!--
# bu-isciii tools pull request

Based on nf-core/viralrecon pull request template

Fill in the appropriate checklist below and delete whatever is not relevant.

PRs should be made against the develop of hotfix branch, unless you're preparing a software release.
-->
## PR description

Enable fastp `--trim_poly_x` by default in `hpc_slurm_assembly.config`.

**Changes**
Added `--trim_poly_x`, and existing arguments in lablog, to the FASTP process extra arguments:
```
--trim_poly_x
--qualified_quality_phred 20
--cut_mean_quality 20
```
Removed fastp arguments from lablog, as they are now stored in config file

Resolves #684 

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`black and flake8`).
- If a new tamplate was added make sure:
    - [ ] Template's schema is added in `templates/services.json`.
    - [ ] Template's pipeline's documentation in `assets/reports/md/template.md` is added.
    - [ ] Results Documentation in `assets/reports/results/template.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
- [ ] If you know a new user was added to the SFTP, make sure you added it to `templates/sftp_user.json`
