### PR TITLE
Fixed linting checks after a PR is merged

### DIFF
--- a/.github/workflows/python_lint.yml
+++ b/.github/workflows/python_lint.yml
@@ -26,7 +26,7 @@ jobs:
         id: file_check
         uses: tj-actions/changed-files@v44
         with:
-          sha: ${{ github.event.pull_request.head.sha }}
+          sha: ${{ github.event.pull_request.head.sha || github.sha }}
           files: |
              **.py
       - name: Run flake8
@@ -49,7 +49,7 @@ jobs:
           id: file_check
           uses: tj-actions/changed-files@v44
           with:
-            sha: ${{ github.event.pull_request.head.sha }}
+            sha: ${{ github.event.pull_request.head.sha || github.sha }}
             files: '**.py'
         - name: Check code lints with Black
           if: steps.file_check.outputs.any_changed == 'true'


### PR DESCRIPTION
<!--
# bu-isciii tools pull request

Based on nf-core/viralrecon pull request template

Fill in the appropriate checklist below and delete whatever is not relevant.

PRs should be made against the develop of hotfix branch, unless you're preparing a software release.
-->

## PR checklist

- [X] This comment contains a description of changes (with reason).
- [X] Make sure your code lints (`black and flake8`).
- If a new tamplate was added make sure:
    - [ ] Template's schema is added in `templates/services.json`.
    - [ ] Template's pipeline's documentation in `assets/reports/md/template.md` is added.
    - [ ] Results Documentation in `assets/reports/results/template.md` is updated.
- [X] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
- [ ] If you know a new user was added to the SFTP, make sure you added it to `templates/sftp_user.json`

## PR description

Closes #688.