### PR TITLE
Enabled explicit local access for wkhtmltopdf. Fixes #704

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.4dev] - 2026-XX-XX : https://github.com/BU-ISCIII/buisciii-tools/releases/tag/2.3.4dev
+
+### Credits
+
+- [Enrique Sapena](https://github.com/ESapenaVentura)
+
+### Template fixes and updates
+
+### Modules
+
+#### Implementation
+
+#### Added enhancements
+
+#### Fixes
+
+- Fixed local file access for PDF generation via wkhtmltopdf [#705](https://github.com/BU-ISCIII/buisciii-tools/pull/705)
+
+#### Changed
+
+#### Removed
+
+### Requirements
+
 ## [2.3.3] - 2026-06-22 : https://github.com/BU-ISCIII/buisciii-tools/releases/tag/2.3.3
 
 ### Credits

--- a/buisciii/bioinfo_doc.py
+++ b/buisciii/bioinfo_doc.py
@@ -552,7 +552,10 @@ class BioinfoDoc:
         pdf_file = html_file.replace(".html", ".pdf")
         try:
             pdfkit.from_file(
-                html_file, output_path=pdf_file, configuration=self.config_pdfkit
+                html_file,
+                output_path=pdf_file,
+                configuration=self.config_pdfkit,
+                options={"enable-local-file-access": ""},
             )
             log.info(f"PDF file created successfully: {pdf_file}")
         except OSError as e:


### PR DESCRIPTION
This PR fixes #704 , at least regarding assembly services, by adding the option "enable-local-acces" to pdfkit's call to wkhtmltopdf.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`black and flake8`).
- [x] `CHANGELOG.md` is updated.
~- [ ] `README.md` is updated (including new tool citations and authors/contributors).~
~- [ ] If you know a new user was added to the SFTP, make sure you added it to `templates/sftp_user.json`~
