### PR TITLE
Updated assembly template to skip busco and some paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Updated assembly config for MultiQC and RESULTS lablog [#708](https://github.com/BU-ISCIII/buisciii-tools/pull/708)
 - Updated iGenomes paths [#710](https://github.com/BU-ISCIII/buisciii-tools/pull/710)
+- Updated the assembly template to skip busco and some paths in correspondence to refgenie system [#711](https://github.com/BU-ISCIII/buisciii-tools/pull/711)
 
 ### Modules
 

--- a/buisciii/templates/assembly/ANALYSIS/ANALYSIS01_ASSEMBLY/lablog
+++ b/buisciii/templates/assembly/ANALYSIS/ANALYSIS01_ASSEMBLY/lablog
@@ -123,6 +123,7 @@ nextflow run /data/ucct/bi/pipelines/nf-core-bacass/nf-core-bacass-2.5.0/main.nf
         --save_trimmed ${SAVETRIMMED} \\
         --skip_kraken2 true \\
         --skip_kmerfinder false \\
+        --skip_busco true \\
         --kmerfinderdb /data/ucct/bi/references/kmerfinder/latest/bacteria \\
         --ncbi_assembly_metadata /data/ucct/bi/references/bacteria/20240626/assembly_summary_refseq.txt \\
         ${PROKKA_ARGS} \\

--- a/buisciii/templates/characterization/ANALYSIS/ANALYSIS01_CHARACTERIZATION/02-ariba/lablog
+++ b/buisciii/templates/characterization/ANALYSIS/ANALYSIS01_CHARACTERIZATION/02-ariba/lablog
@@ -1,3 +1,3 @@
 # module load singularity
 
-cp /data/ucct/bi/references/ariba/databases.txt .
+cp /data/ucct/bi/references/refgenie/alias/ariba/databases.txt .

--- a/buisciii/templates/characterization/ANALYSIS/ANALYSIS01_CHARACTERIZATION/05-mlva/lablog
+++ b/buisciii/templates/characterization/ANALYSIS/ANALYSIS01_CHARACTERIZATION/05-mlva/lablog
@@ -6,7 +6,7 @@ mkdir MLVA_output
 scratch_dir=$(pwd | sed 's|/data/ucct/bi/scratch_tmp|/scratch|g')
 cp ../../*_ASSEMBLY/03-assembly/unicycler/*.fasta* assemblies/
 gzip -d assemblies/*.fasta.gz
-available_primers=$(ls /data/ucct/bi/references/MLVA/*primer* | rev | cut -d "/" -f1 | rev | cut -d "_" -f1)
+available_primers=$(ls /data/ucct/bi/references/refgenie/alias/MLVA/primers/v20231004/*primer* | rev | cut -d "/" -f1 | rev | cut -d "_" -f1)
 
 echo "Available primers:"
 select primer in $available_primers; do
@@ -18,6 +18,6 @@ select primer in $available_primers; do
     fi
 done
 
-primer_file=$(ls /data/ucct/bi/references/MLVA/${primer}*)
+primer_file=$(ls /data/ucct/bi/references/refgenie/alias/MLVA/primers/v20231004/${primer}*)
 
 echo "srun --partition short_idx --chdir ${scratch_dir} --output logs/MLVA.log --job-name MLVA python /data/ucct/bi/pipelines/mlva/MLVA_finder.py -c -i assemblies -o MLVA_output -p ${primer_file} --full-locus-name --predicted-PCR-size-table --flanking-seq 20 &"  > _01_mlva.sh

--- a/buisciii/templates/pikavirus/DOC/hpc_slurm_pikavirus.config
+++ b/buisciii/templates/pikavirus/DOC/hpc_slurm_pikavirus.config
@@ -10,7 +10,7 @@ process {
 params {
   config_profile_name = 'ISCIII HPC profile'
   config_profile_description = 'Profile designed for the High Performance Computer in the ISCIII'
-  kraken2_db = "/data/ucct/bi/references/kraken/minikraken_8GB_20200312"
+  kraken2_db = "/data/ucct/bi/references/refgenie/alias/kraken/minikraken_8GB/v20200312"
   vir_ref_dir = "/data/ucct/bi/references/PikaVirus/viral_assemblies_for_pikavirus"
   vir_dir_repo = "/data/ucct/bi/references/PikaVirus/viral_assemblies.tsv"
   bact_ref_dir = "/data/ucct/bi/references/PikaVirus/bacteria_assemblies_for_pikavirus"

--- a/buisciii/templates/viralrecon/DOC/viralrecon_sars_nanopore.config
+++ b/buisciii/templates/viralrecon/DOC/viralrecon_sars_nanopore.config
@@ -10,7 +10,7 @@ process {
         withName: 'ARTIC_MINION' {
             ext.args = [
                 '--normalise 500',
-                '--scheme-directory /data/ucct/bi/references/virus/2019-nCoV/primer_schemes/',
+                '--scheme-directory /data/ucct/bi/references/refgenie/alias/coronaviridae/primer_schemes/',
                 '--medaka'
             ].join(' ').trim()
         }


### PR DESCRIPTION
<!--
# bu-isciii tools pull request

Based on nf-core/viralrecon pull request template

Fill in the appropriate checklist below and delete whatever is not relevant.

PRs should be made against the develop of hotfix branch, unless you're preparing a software release.
-->

## PR checklist

- [X] This comment contains a description of changes (with reason).
- [X] Make sure your code lints (`black and flake8`).
- If a new tamplate was added make sure:
    - [ ] Template's schema is added in `templates/services.json`.
    - [ ] Template's pipeline's documentation in `assets/reports/md/template.md` is added.
    - [ ] Results Documentation in `assets/reports/results/template.md` is updated.
- [X] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
- [ ] If you know a new user was added to the SFTP, make sure you added it to `templates/sftp_user.json`

## PR description

This PR updates the assembly template to skip busco and some paths in correspondence to the refgenie system.
