### PR TITLE
Fix IRMA stats generation when 3-match is absent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,30 +4,6 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.3.5]_dev - XXXX-XX-XX : https://github.com/BU-ISCIII/buisciii-tools/releases/tag/2.3.5_dev
-
-### Credits
-
-- [Pau Pascual](https://github.com/PauPascualMas)
-
-### Template fixes and updates
-
-- Fix IRMA stats generation when 3-match is absent [#719](https://github.com/BU-ISCIII/buisciii-tools/pull/719)
-
-### Modules
-
-#### Implementation
-
-#### Added enhancements
-
-#### Fixes
-
-#### Changed
-
-#### Removed
-
-### Requirements
-
 
 ## [2.3.4] - 2026-07-02 : https://github.com/BU-ISCIII/buisciii-tools/releases/tag/2.3.4
 
@@ -36,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [Enrique Sapena](https://github.com/ESapenaVentura)
 - [Victor Lopez](https://github.com/victor5lm)
 - [Sara Monzon](https://github.com/saramonzon)
+- [Pau Pascual](https://github.com/PauPascualMas)
 
 ### Template fixes and updates
 
@@ -48,6 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Updated the Snippy IQ-TREE workflow to reuse the detected best-fit model [#718](https://github.com/BU-ISCIII/buisciii-tools/pull/718)
 - Enhanced the outbreak summary workbook with normalized sample IDs, updated AMRFinderPlus parsing, SNP distance tables, provenance, and consistent formatting [#718](https://github.com/BU-ISCIII/buisciii-tools/pull/718)
 - Added reusable Snippy SNP-distance matrices and close-pair variant QC tooling [#718](https://github.com/BU-ISCIII/buisciii-tools/pull/718)
+- Fix IRMA stats generation when 3-match is absent [#719](https://github.com/BU-ISCIII/buisciii-tools/pull/719)
 
 ### Modules
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,31 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.5]_dev - XXXX-XX-XX : https://github.com/BU-ISCIII/buisciii-tools/releases/tag/2.3.5_dev
+
+### Credits
+
+- [Pau Pascual](https://github.com/PauPascualMas)
+
+### Template fixes and updates
+
+- Fix IRMA stats generation when 3-match is absent [#719](https://github.com/BU-ISCIII/buisciii-tools/pull/719)
+
+### Modules
+
+#### Implementation
+
+#### Added enhancements
+
+#### Fixes
+
+#### Changed
+
+#### Removed
+
+### Requirements
+
+
 ## [2.3.4] - 2026-07-02 : https://github.com/BU-ISCIII/buisciii-tools/releases/tag/2.3.4
 
 ### Credits

--- a/buisciii/templates/IRMA/ANALYSIS/ANALYSIS01_IRMA/04-irma/create_irma_stats_flu.sh
+++ b/buisciii/templates/IRMA/ANALYSIS/ANALYSIS01_IRMA/04-irma/create_irma_stats_flu.sh
@@ -1,43 +1,105 @@
+#!/usr/bin/env bash
 
-echo -e "sample_ID\tTotalReads\tMappedReads\t%MappedReads\tFlu_type\tReads_HA\tReads_MP\tReads_NA\tReads_NP\tReads_NS\tReads_PA\tReads_PB1\tReads_PB2" > irma_stats_flu.txt
+OUTPUT="irma_stats_flu.txt"
 
-cat ../samples_id.txt | while read in 
-do
-    SAMPLE_ID=$(echo ${in})
-    TOTAL_READS=""; MAPPEDREADS=""; PCTMAPPED=""; FLU_TYPE=""; HA=""; MP=""; NA=""; NP=""; NS=""; PA=""; PB1=""; PB2=""; HE=""
+echo -e "sample_ID\tTotalReads\tMappedReads\t%MappedReads\tFlu_type\tReads_HA\tReads_MP\tReads_NA\tReads_NP\tReads_NS\tReads_PA\tReads_PB1\tReads_PB2" > "$OUTPUT"
 
-    if test -f ${in}/tables/READ_COUNTS.txt; then
-        TOTAL_READS=$(grep '1-initial' ${in}/tables/READ_COUNTS.txt | cut -f2)
-        MAPPEDREADS=$(grep '3-match' ${in}/tables/READ_COUNTS.txt | cut -f2)
-        PCTMAPPED=$(awk "BEGIN {printf \"%.2f\", ($MAPPEDREADS/$TOTAL_READS)*100}")
-        FLU_TYPE=$(paste <(grep '4-[A-C]' ${in}/tables/READ_COUNTS.txt | cut -f1 | cut -d '_' -f1 | cut -d '-' -f2 | head -n1 ) <(grep '4-[A-B]_HA' ${in}/tables/READ_COUNTS.txt | cut -f1 | cut -d '_' -f3 | cut -d '-' -f2) <(grep '4-[A-B]_NA' ${in}/tables/READ_COUNTS.txt | cut -f1 | cut -d '_' -f3) | tr '\t' '_' | sed 's/_*$//')
-        HA=$(grep '4-[A-C]_HA' ${in}/tables/READ_COUNTS.txt | cut -f2)
-        MP=$(grep '4-[A-C]_MP' ${in}/tables/READ_COUNTS.txt | cut -f2)
-        NA=$(grep '4-[A-C]_NA' ${in}/tables/READ_COUNTS.txt | cut -f2)
-        NP=$(grep '4-[A-C]_NP' ${in}/tables/READ_COUNTS.txt | cut -f2)
-        NS=$(grep '4-[A-C]_NS' ${in}/tables/READ_COUNTS.txt | cut -f2)
-        PA=$(grep '4-[A-C]_PA' ${in}/tables/READ_COUNTS.txt | cut -f2)
-        PB1=$(grep '4-[A-C]_PB1' ${in}/tables/READ_COUNTS.txt | cut -f2)
-        PB2=$(grep '4-[A-C]_PB2' ${in}/tables/READ_COUNTS.txt | cut -f2)
-        #In case of Influenza C in samples:
-        HE=$(grep '4-C_HE' ${in}/tables/READ_COUNTS.txt | cut -f2)
+while read -r in; do
+    [[ -z "$in" ]] && continue
+
+    SAMPLE_ID="$in"
+    FILE="${in}/tables/READ_COUNTS.txt"
+
+    if [[ -f "$FILE" ]]; then
+        read -r TOTAL_READS MAPPEDREADS PCTMAPPED < <(
+            awk -F'\t' '
+                $1=="1-initial" {t=$2}
+                $1=="3-match"   {m=$2}
+                END {
+                    t += 0
+                    m += 0
+
+                    if (t > 0) {
+                        pct = (m / t) * 100
+                    } else {
+                        pct = 0
+                    }
+
+                    printf "%d %d %.2f\n", t, m, pct
+                }
+            ' "$FILE"
+        )
+
+        FLU_TYPE=$(paste \
+            <(grep '4-[A-C]' "$FILE" | cut -f1 | cut -d_ -f1 | cut -d- -f2 | head -n1) \
+            <(grep '4-[A-B]_HA' "$FILE" | cut -f1 | cut -d_ -f3 | cut -d- -f2) \
+            <(grep '4-[A-B]_NA' "$FILE" | cut -f1 | cut -d_ -f3) \
+            | tr '\t' '_' \
+            | sed 's/_*$//'
+        )
+
+        HA=$(grep -m1 '4-[A-C]_HA' "$FILE" | cut -f2)
+        MP=$(grep -m1 '4-[A-C]_MP' "$FILE" | cut -f2)
+        NA=$(grep -m1 '4-[A-C]_NA' "$FILE" | cut -f2)
+        NP=$(grep -m1 '4-[A-C]_NP' "$FILE" | cut -f2)
+        NS=$(grep -m1 '4-[A-C]_NS' "$FILE" | cut -f2)
+        PA=$(grep -m1 '4-[A-C]_PA' "$FILE" | cut -f2)
+        PB1=$(grep -m1 '4-[A-C]_PB1' "$FILE" | cut -f2)
+        PB2=$(grep -m1 '4-[A-C]_PB2' "$FILE" | cut -f2)
+        HE=$(grep -m1 '4-C_HE' "$FILE" | cut -f2)
+
         if [[ -n "$HE" ]]; then
-            LINE=$(paste <(echo $SAMPLE_ID) <(echo $TOTAL_READS) <(echo $MAPPEDREADS) <(echo $PCTMAPPED) <(echo $FLU_TYPE) <(echo $HA) <(echo $MP) <(echo $NA) <(echo $NP) <(echo $NS) <(echo $PA) <(echo $PB1) <(echo $PB2) <(echo $HE))
+            printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n" \
+                "$SAMPLE_ID" \
+                "$TOTAL_READS" \
+                "$MAPPEDREADS" \
+                "$PCTMAPPED" \
+                "$FLU_TYPE" \
+                "$HA" \
+                "$MP" \
+                "$NA" \
+                "$NP" \
+                "$NS" \
+                "$PA" \
+                "$PB1" \
+                "$PB2" \
+                "$HE" \
+                >> "$OUTPUT"
         else
-            LINE=$(paste <(echo $SAMPLE_ID) <(echo $TOTAL_READS) <(echo $MAPPEDREADS) <(echo $PCTMAPPED) <(echo $FLU_TYPE) <(echo $HA) <(echo $MP) <(echo $NA) <(echo $NP) <(echo $NS) <(echo $PA) <(echo $PB1) <(echo $PB2))
+            printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n" \
+                "$SAMPLE_ID" \
+                "$TOTAL_READS" \
+                "$MAPPEDREADS" \
+                "$PCTMAPPED" \
+                "$FLU_TYPE" \
+                "$HA" \
+                "$MP" \
+                "$NA" \
+                "$NP" \
+                "$NS" \
+                "$PA" \
+                "$PB1" \
+                "$PB2" \
+                >> "$OUTPUT"
         fi
+
     else
         echo "Sample $SAMPLE_ID doesn't have READ_COUNTS.txt file. Skipping"
-        TOTAL_READS=NA
-        MAPPEDREADS=0
-        PCTMAPPED=0
-        LINE=$(paste <(echo $SAMPLE_ID) <(echo $TOTAL_READS) <(echo $MAPPEDREADS) <(echo $PCTMAPPED))
+
+        printf "%s\tNA\t0\t0.00\t\t\t\t\t\t\t\t\t\n" \
+            "$SAMPLE_ID" \
+            >> "$OUTPUT"
     fi
 
-    echo "$LINE" >> irma_stats_flu.txt
-done
+done < ../samples_id.txt
 
-ANY_C=$(grep "C" irma_stats_flu.txt)
-if [[ -n "$ANY_C" ]]; then
-    sed -i 's/Reads_PB2/Reads_PB2\tReads_HE/g' irma_stats_flu.txt
+if awk -F'\t' '
+    NR > 1 && NF >= 14 && $14 != "" {
+        found = 1
+    }
+    END {
+        exit(found ? 0 : 1)
+    }
+' "$OUTPUT"; then
+    sed -i '1s/Reads_PB2$/Reads_PB2\tReads_HE/' "$OUTPUT"
 fi

--- a/buisciii/templates/IRMA/ANALYSIS/ANALYSIS01_IRMA/04-irma/create_irma_stats_rsv.sh
+++ b/buisciii/templates/IRMA/ANALYSIS/ANALYSIS01_IRMA/04-irma/create_irma_stats_rsv.sh
@@ -1,11 +1,39 @@
+#!/usr/bin/env bash
+
 echo -e "Sample_ID\tTotalReads\tMappedReads\t%MappedReads\tRSV_type" > irma_stats_rsv.txt
 
-cat ../samples_id.txt | while read in 
-do 
-SAMPLE_ID=$(echo ${in})
-TOTAL_READS=$(grep '1-initial' ${in}/tables/READ_COUNTS.txt | cut -f2)
-MAPPEDREADS=$(grep '3-match' ${in}/tables/READ_COUNTS.txt | cut -f2)
-PCTMAPPED=$(awk "BEGIN {printf \"%.2f\", ($MAPPEDREADS/$TOTAL_READS)*100}")
-RSV_TYPE=$(grep '4-RSV_' ${in}/tables/READ_COUNTS.txt | cut -f1 | cut -d '_' -f2)
-echo -e "${SAMPLE_ID}\t${TOTAL_READS}\t${MAPPEDREADS}\t${PCTMAPPED}\t${RSV_TYPE}" >> irma_stats_rsv.txt
-done
+while read -r in; do
+    SAMPLE_ID="$in"
+    FILE="${in}/tables/READ_COUNTS.txt"
+
+    if [[ -f "$FILE" ]]; then
+        read -r TOTAL_READS MAPPEDREADS PCTMAPPED < <(
+            awk -F'\t' '
+                $1=="1-initial" {t=$2}
+                $1=="3-match"   {m=$2}
+                END {
+                    t+=0
+                    m+=0
+                    printf "%d %d %.2f\n", t, m, t>0 ? (m/t)*100 : 0
+                }
+            ' "$FILE"
+        )
+
+        RSV_TYPE=$(grep '4-RSV_' "$FILE" | cut -f1 | cut -d_ -f2)
+    else
+        echo "Sample $SAMPLE_ID doesn't have READ_COUNTS.txt file. Skipping"
+        TOTAL_READS="NA"
+        MAPPEDREADS=0
+        PCTMAPPED="0.00"
+        RSV_TYPE=""
+    fi
+
+    printf "%s\t%s\t%s\t%s\t%s\n" \
+        "$SAMPLE_ID" \
+        "$TOTAL_READS" \
+        "$MAPPEDREADS" \
+        "$PCTMAPPED" \
+        "$RSV_TYPE" \
+        >> irma_stats_rsv.txt
+
+done < ../samples_id.txt


### PR DESCRIPTION
<!--
# bu-isciii tools pull request

Based on nf-core/viralrecon pull request template

Fill in the appropriate checklist below and delete whatever is not relevant.

PRs should be made against the develop of hotfix branch, unless you're preparing a software release.
-->
## PR description

This PR updates the FLU and RSV IRMA statistics scripts to handle samples where tables/READ_COUNTS.txt` does not contain a 3-match row.

Previously, both scripts assumed that 3-match was always present:

```
MAPPEDREADS=$(grep '3-match' ... | cut -f2)
PCTMAPPED=$(awk "BEGIN {printf \"%.2f\", ($MAPPEDREADS/$TOTAL_READS)*100}")
```

When no reads matched the reference, IRMA could produce only entries such as:

```
3-chimeric    0
3-nomatch     621695

```
with no 3-match row. In that case, MAPPEDREADS was empty and the generated awk expression became invalid, causing the script to fail with errors such as:

`awk: unterminated regexp`

### Changes

- Update the FLU stats script to:
- read 1-initial and 3-match safely;
- default missing 3-match values to 0;
- avoid division by zero;
- report 0.00 mapped percentage when appropriate.
- Update the RSV stats script with the same behavior.
- Preserve processing of the remaining samples instead of terminating because of a single sample with no mapped reads.
- Improve FLU Influenza C detection so it does not rely on a generic search for the letter C, which may match sample names such as Canarias, Cantabria, or Ceuta.
- Expected behavior

For a sample with:

```
1-initial    1389472
3-nomatch     621695
```

and no 3-match row, both stats scripts now produce:

```
MappedReads     0
%MappedReads    0.00
```

instead of failing.

### Impact

This makes FLU and RSV summary generation more robust for samples with zero reads matching the reference and prevents one malformed or zero-match case from stopping the full reporting workflow.

This resolves Issue #715 

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`black and flake8`).
- If a new tamplate was added make sure:
    - [ ] Template's schema is added in `templates/services.json`.
    - [ ] Template's pipeline's documentation in `assets/reports/md/template.md` is added.
    - [ ] Results Documentation in `assets/reports/results/template.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
- [ ] If you know a new user was added to the SFTP, make sure you added it to `templates/sftp_user.json`
