### PR TITLE
Changed bind to refgenie to access properly the databases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [Victor Lopez](https://github.com/victor5lm)
 - [Sara Monzon](https://github.com/saramonzon)
 - [Pau Pascual](https://github.com/PauPascualMas)
+- [Juan Ledesma](https://github.com/juanledesma78)
 
 ### Template fixes and updates
 
@@ -26,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Enhanced the outbreak summary workbook with normalized sample IDs, updated AMRFinderPlus parsing, SNP distance tables, provenance, and consistent formatting [#718](https://github.com/BU-ISCIII/buisciii-tools/pull/718)
 - Added reusable Snippy SNP-distance matrices and close-pair variant QC tooling [#718](https://github.com/BU-ISCIII/buisciii-tools/pull/718)
 - Fix IRMA stats generation when 3-match is absent [#719](https://github.com/BU-ISCIII/buisciii-tools/pull/719)
+- Modified bind in BLAST lablog to alow access to refgenie data [#722](https://github.com/BU-ISCIII/buisciii-tools/pull/722)
 
 ### Modules
 

--- a/buisciii/templates/blast_nt/ANALYSIS/ANALYSIS02_BLAST/lablog
+++ b/buisciii/templates/blast_nt/ANALYSIS/ANALYSIS02_BLAST/lablog
@@ -29,7 +29,7 @@ cat ../samples_id.txt | while read in; do
 done 
 
 # NOTE3: change the -query flag to meet your requirements
-cat ../samples_id.txt | xargs -I %% echo "srun --chdir ${scratch_dir} --partition middle_idx --mem 200G --time 48:00:00 --cpus-per-task 10 --output logs/BLASTN_%%_%j.log --job-name BLASTN_%% singularity exec -B ${scratch_dir}/../../ -B /data/ucct/bi/references/refgenie/alias/BLAST/viral_assemblies/v20260318/ /data/ucct/bi/pipelines/singularity-images/blast:2.17.0--h66d330f_0 blastn -num_threads 10 -db ${BLAST_DATABASE} -query ${scratch_dir}/%%/%%.scaffolds.fa -out ${scratch_dir}/%%/%%_blast.tsv -outfmt '6 qseqid stitle qaccver saccver pident length mismatch gaps qstart qend sstart send evalue bitscore slen qlen qcovs' &" > _01_blast.sh
+cat ../samples_id.txt | xargs -I %% echo "srun --chdir ${scratch_dir} --partition middle_idx --mem 200G --time 48:00:00 --cpus-per-task 10 --output logs/BLASTN_%%_%j.log --job-name BLASTN_%% singularity exec -B ${scratch_dir}/../../ -B /data/ucct/bi/references/refgenie/ /data/ucct/bi/pipelines/singularity-images/blast:2.17.0--h66d330f_0 blastn -num_threads 10 -db ${BLAST_DATABASE} -query ${scratch_dir}/%%/%%.scaffolds.fa -out ${scratch_dir}/%%/%%_blast.tsv -outfmt '6 qseqid stitle qaccver saccver pident length mismatch gaps qstart qend sstart send evalue bitscore slen qlen qcovs' &" > _01_blast.sh
 
 # Filtering criteria:
     # %refCovered > 0.7


### PR DESCRIPTION
The path (-B) to the databases in refgenie has been changed in the lablog so now the software can properly access the data.
This modification fised the issue described in https://github.com/BU-ISCIII/buisciii-tools/issues/721
<!--
# bu-isciii tools pull request

Based on nf-core/viralrecon pull request template

Fill in the appropriate checklist below and delete whatever is not relevant.

PRs should be made against the develop of hotfix branch, unless you're preparing a software release.
-->

## PR checklist

- [X] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`black and flake8`).
- If a new tamplate was added make sure:
    - [ ] Template's schema is added in `templates/services.json`.
    - [ ] Template's pipeline's documentation in `assets/reports/md/template.md` is added.
    - [ ] Results Documentation in `assets/reports/results/template.md` is updated.
- [X] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
- [ ] If you know a new user was added to the SFTP, make sure you added it to `templates/sftp_user.json`
