### PR TITLE
Enhanced SNP QC script and updated snippy's template accordingly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix IRMA stats generation when 3-match is absent [#719](https://github.com/BU-ISCIII/buisciii-tools/pull/719)
 - Modified bind in BLAST lablog to alow access to refgenie data [#722](https://github.com/BU-ISCIII/buisciii-tools/pull/722)
 - Enhanced the SNP QC script from snippy's template [#724](https://github.com/BU-ISCIII/buisciii-tools/pull/724).
-- Fix lablog_assembly FASTQ matching with shared sample prefix (https://github.com/BU-ISCIII/buisciii-tools/pull/726).
+- Fix lablog_assembly FASTQ matching with shared sample prefix [#726](https://github.com/BU-ISCIII/buisciii-tools/pull/726).
 
 ### Modules
 

--- a/buisciii/templates/snippy/ANALYSIS/ANALYSIS01_SNIPPY/05-snippy/evaluate_close_pairs.py
+++ b/buisciii/templates/snippy/ANALYSIS/ANALYSIS01_SNIPPY/05-snippy/evaluate_close_pairs.py
@@ -153,12 +153,6 @@ def parse_args() -> argparse.Namespace:
         help="Do not write the human-readable variant summary table",
     )
     parser.add_argument(
-        "--no-column-descriptions",
-        dest="no_data_dictionary",
-        action="store_true",
-        help="Do not write the TSV column descriptions",
-    )
-    parser.add_argument(
         "--no-metadata",
         action="store_true",
         help="Do not write the JSON run metadata and provenance file",
@@ -879,20 +873,28 @@ def column_description(column: str) -> tuple[str, str]:
     return ("Column descriptions generated!")
 
 
-def write_data_dictionary(path: Path, pairs_path: Path, variants_path: Path, summary_path: Path | None) -> None:
-    """Create a versioned TSV dictionary from the actual headers written"""
+def build_data_dictionary_rows(
+    pairs_path: Path, variants_path: Path, summary_path: Path | None
+) -> list[dict[str, str]]:
+    """Build column descriptions for display in the Excel report only."""
     tables = [(pairs_path.name, pairs_path), (variants_path.name, variants_path)]
     if summary_path is not None:
         tables.append((summary_path.name, summary_path))
-    with path.open("w", newline="") as handle:
-        writer = csv.DictWriter(handle, fieldnames=["table", "column", "source_field_or_calculation", "meaning"], delimiter="\t")
-        writer.writeheader()
-        for table_name, table_path in tables:
-            with table_path.open(newline="") as table:
-                headers = next(csv.reader(table, delimiter="\t"), [])
-            for column in headers:
-                source, description = column_description(column)
-                writer.writerow({"table": table_name, "column": column, "source_field_or_calculation": source, "meaning": description})
+    rows = []
+    for table_name, table_path in tables:
+        with table_path.open(newline="") as table:
+            headers = next(csv.reader(table, delimiter="\t"), [])
+        for column in headers:
+            source, description = column_description(column)
+            rows.append(
+                {
+                    "table": table_name,
+                    "column": column,
+                    "source_field_or_calculation": source,
+                    "meaning": description,
+                }
+            )
+    return rows
 
 
 
@@ -962,7 +964,6 @@ def write_excel_report(
     pairs_path: Path,
     variants_path: Path,
     summary_path: Path | None,
-    dictionary_path: Path | None,
     args: argparse.Namespace,
     sample_count: int,
     core_site_count: int,
@@ -1003,8 +1004,7 @@ def write_excel_report(
     ]
     if summary_path is not None:
         sheet_entries.append(("Variant summary", "A compact version of the SNP-variant table.", "Use it for manual evaluation; consult SNP variants sheet to check all fields."))
-    if dictionary_path is not None:
-        sheet_entries.append(("Column descriptions", "Definition and exact source field or calculation for every output column.", "Check this sheet to find the meaning of each column field."))
+    sheet_entries.append(("Column descriptions", "Definition and exact source field or calculation for every output column.", "Check this sheet to find the meaning of each column field."))
     for entry in sheet_entries:
         readme.append(entry)
     for row in readme.iter_rows():
@@ -1020,12 +1020,16 @@ def write_excel_report(
     ]
     if summary_path is not None:
         sheets.append(("Variant summary", summary_path))
-    if dictionary_path is not None:
-        sheets.append(("Column descriptions", dictionary_path))
     for sheet_name, table_path in sheets:
         worksheet = workbook.create_sheet(sheet_name)
         headers, rows = read_tsv_rows(table_path)
         style_table_worksheet(worksheet, headers, rows)
+    dictionary = workbook.create_sheet("Column descriptions")
+    style_table_worksheet(
+        dictionary,
+        ["table", "column", "source_field_or_calculation", "meaning"],
+        build_data_dictionary_rows(pairs_path, variants_path, summary_path),
+    )
     workbook.save(path)
 
 
@@ -1377,10 +1381,6 @@ def main() -> int:
     if not args.no_summary:
         summary_path = prefix.with_name(prefix.name + "_variants_summary.tsv")
         write_variant_summary(summary_path, variant_rows)
-    dictionary_path = None
-    if not args.no_data_dictionary:
-        dictionary_path = prefix.with_name(prefix.name + "_column_descriptions.tsv")
-        write_data_dictionary(dictionary_path, pairs_path, variants_path, summary_path)
     excel_path = None
     if not args.no_excel:
         excel_path = args.excel_output or prefix.with_name(prefix.name + "_report.xlsx")
@@ -1388,7 +1388,7 @@ def main() -> int:
             excel_path = Path.cwd() / excel_path
         try:
             write_excel_report(
-                excel_path, pairs_path, variants_path, summary_path, dictionary_path,
+                excel_path, pairs_path, variants_path, summary_path,
                 args, len(samples), len(sites),
             )
         except RuntimeError as error:
@@ -1408,8 +1408,6 @@ def main() -> int:
     print(f"Wrote: {variants_path}")
     if summary_path:
         print(f"Wrote: {summary_path}")
-    if dictionary_path:
-        print(f"Wrote: {dictionary_path}")
     if excel_path:
         print(f"Wrote: {excel_path}")
     if metadata_path:

--- a/buisciii/templates/snippy/ANALYSIS/ANALYSIS01_SNIPPY/05-snippy/evaluate_close_pairs.py
+++ b/buisciii/templates/snippy/ANALYSIS/ANALYSIS01_SNIPPY/05-snippy/evaluate_close_pairs.py
@@ -467,10 +467,10 @@ def read_bam_pileup(
 
     Sites are written as 0-based half-open BED intervals. Mapping quality
     (``-q``) and base quality (``-Q``) are applied before parsing A/C/G/T
-    support and strand orientation from the read-bases field. This tool is 
+    support and strand orientation from the read-bases field. This tool is
     run without skipping anomalous read pairs (-A), disabling base alignment
-    quality (BAQ) computation (-B) and disabling overlap detection and removal (-x), 
-    with the objective of obtaining results as similar as the ones that samtools depth 
+    quality (BAQ) computation (-B) and disabling overlap detection and removal (-x),
+    with the objective of obtaining results as similar as the ones that samtools depth
     would report, which is the tool being employed by snippy to mask low-depth positions.
     """
     if not positions:

--- a/buisciii/templates/snippy/ANALYSIS/ANALYSIS01_SNIPPY/05-snippy/evaluate_close_pairs.py
+++ b/buisciii/templates/snippy/ANALYSIS/ANALYSIS01_SNIPPY/05-snippy/evaluate_close_pairs.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Find closely related Snippy samples and report their differing SNPs.
 
-Distances are calculated directly from snippy-core's core.tab.  For each pair
+Distances are calculated directly from snippy-core's core.tab. For each pair
 below the requested threshold, the script looks up supporting read counts in
 each sample's snps.vcf (or snps.vcf.gz). Reference calls, which are absent
 from variant-only VCFs, are measured from snps.bam with samtools mpileup.
@@ -467,7 +467,11 @@ def read_bam_pileup(
 
     Sites are written as 0-based half-open BED intervals. Mapping quality
     (``-q``) and base quality (``-Q``) are applied before parsing A/C/G/T
-    support and strand orientation from the read-bases field.
+    support and strand orientation from the read-bases field. This tool is 
+    run without skipping anomalous read pairs (-A), disabling base alignment
+    quality (BAQ) computation (-B) and disabling overlap detection and removal (-x), 
+    with the objective of obtaining results as similar as the ones that samtools depth 
+    would report, which is the tool being employed by snippy to mask low-depth positions.
     """
     if not positions:
         return {}
@@ -478,6 +482,9 @@ def read_bam_pileup(
         command = [
             samtools,
             "mpileup",
+            "-A",
+            "-B",
+            "-x",
             "-q",
             str(minimum_mapq),
             "-Q",
@@ -782,19 +789,24 @@ def enhance_output_tables(
         if (not field.startswith("sample_") or field in ("sample_1", "sample_2"))
         and field != "qc_warnings"
     ]
+    ordered_context_fields = []
+    for field in context_fields:
+        ordered_context_fields.append(field)
+        if field == "core_ref":
+            ordered_context_fields.extend(("sample_1_call", "sample_2_call"))
+        if field == "removed_by_gubbins":
+            ordered_context_fields.append("qc_warnings")
     sample_1_fields = [
         field
         for field in variant_fields + derived_fields
-        if field.startswith("sample_1_")
+        if field.startswith("sample_1_") and field != "sample_1_call"
     ]
     sample_2_fields = [
         field
         for field in variant_fields + derived_fields
-        if field.startswith("sample_2_")
+        if field.startswith("sample_2_") and field != "sample_2_call"
     ]
-    ordered_variant_fields = (
-        context_fields + sample_1_fields + sample_2_fields + ["qc_warnings"]
-    )
+    ordered_variant_fields = ordered_context_fields + sample_1_fields + sample_2_fields
     with tempfile.NamedTemporaryFile(
         "w", newline="", dir=variants_path.parent, delete=False
     ) as temporary:
@@ -824,6 +836,7 @@ def write_variant_summary(path: Path, rows: list[dict[str, str]]) -> None:
         "sample_2_evidence_summary",
         "removed_by_gubbins",
         "pair_clustered_snp",
+        "qc_warnings",
     ]
     with path.open("w", newline="") as handle:
         writer = csv.DictWriter(handle, fieldnames=fields, delimiter="\t")

--- a/buisciii/templates/snippy/ANALYSIS/ANALYSIS01_SNIPPY/05-snippy/evaluate_close_pairs.py
+++ b/buisciii/templates/snippy/ANALYSIS/ANALYSIS01_SNIPPY/05-snippy/evaluate_close_pairs.py
@@ -663,7 +663,6 @@ def collect_qc_warnings(
     return warnings
 
 
-
 def as_float(value: object) -> float | None:
     """Return a numeric value, or ``None`` when an evidence field is absent."""
     try:
@@ -698,14 +697,22 @@ def annotate_variant_row(row: dict[str, str]) -> dict[str, str]:
         forward = row.get(f"{prefix}_{called_kind}_forward_count", "")
         reverse = row.get(f"{prefix}_{called_kind}_reverse_count", "")
         forward_value, reverse_value = as_float(forward), as_float(reverse)
-        if forward_value is None or reverse_value is None or forward_value + reverse_value == 0:
+        if (
+            forward_value is None
+            or reverse_value is None
+            or forward_value + reverse_value == 0
+        ):
             minor_fraction = ""
         else:
-            minor_fraction = str(min(forward_value, reverse_value) / (forward_value + reverse_value))
+            minor_fraction = str(
+                min(forward_value, reverse_value) / (forward_value + reverse_value)
+            )
         evidence_available = status in ("variant_record", "reference_call_mpileup")
         row[f"{prefix}_called_allele_minor_strand_fraction"] = minor_fraction
         if not evidence_available:
-            row[f"{prefix}_evidence_summary"] = f"{call}: evidence not available ({status})"
+            row[f"{prefix}_evidence_summary"] = (
+                f"{call}: evidence not available ({status})"
+            )
         else:
             row[f"{prefix}_evidence_summary"] = (
                 f"{call}: {format_number(count)}/{format_number(row.get(f'{prefix}_depth', ''))} "
@@ -714,7 +721,9 @@ def annotate_variant_row(row: dict[str, str]) -> dict[str, str]:
     return row
 
 
-def enhance_output_tables(pairs_path: Path, variants_path: Path, threshold: int) -> list[dict[str, str]]:
+def enhance_output_tables(
+    pairs_path: Path, variants_path: Path, threshold: int
+) -> list[dict[str, str]]:
     """Include additional useful interpretation fields to the TSV output files"""
     with pairs_path.open(newline="") as handle:
         reader = csv.DictReader(handle, delimiter="\t")
@@ -726,24 +735,30 @@ def enhance_output_tables(pairs_path: Path, variants_path: Path, threshold: int)
         total = comparable + ignored
         row["comparable_core_fraction"] = "" if total == 0 else str(comparable / total)
         missing = [
-            label for label, field in (
+            label
+            for label, field in (
                 ("core_tab", "core_tab_matrix_distance"),
                 ("phylo", "phylo_aln_distance"),
                 ("clean_core", "clean_core_aln_distance"),
-            ) if not row.get(field, "")
+            )
+            if not row.get(field, "")
         ]
-        row["matrix_availability"] = "all_available" if not missing else "missing:" + ",".join(missing)
+        row["matrix_availability"] = (
+            "all_available" if not missing else "missing:" + ",".join(missing)
+        )
     ordered_pair_fields = []
     for field in pair_fields:
         ordered_pair_fields.append(field)
-
         if field == "ignored_non_acgt_sites":
             ordered_pair_fields.append("comparable_core_fraction")
-
         if field == "snps_removed_by_gubbins":
             ordered_pair_fields.append("matrix_availability")
-    with tempfile.NamedTemporaryFile("w", newline="", dir=pairs_path.parent, delete=False) as temporary:
-        writer = csv.DictWriter(temporary, fieldnames=ordered_pair_fields, delimiter="\t")
+    with tempfile.NamedTemporaryFile(
+        "w", newline="", dir=pairs_path.parent, delete=False
+    ) as temporary:
+        writer = csv.DictWriter(
+            temporary, fieldnames=ordered_pair_fields, delimiter="\t"
+        )
         writer.writeheader()
         writer.writerows(pair_rows)
         temporary_path = Path(temporary.name)
@@ -754,21 +769,38 @@ def enhance_output_tables(pairs_path: Path, variants_path: Path, threshold: int)
         variant_rows = [annotate_variant_row(dict(row)) for row in reader]
         variant_fields = list(reader.fieldnames or [])
     derived_fields = [
-        field for number in (1, 2) for field in (
+        field
+        for number in (1, 2)
+        for field in (
             f"sample_{number}_called_allele_minor_strand_fraction",
             f"sample_{number}_evidence_summary",
         )
     ]
     context_fields = [
-        field for field in variant_fields
+        field
+        for field in variant_fields
         if (not field.startswith("sample_") or field in ("sample_1", "sample_2"))
         and field != "qc_warnings"
     ]
-    sample_1_fields = [field for field in variant_fields + derived_fields if field.startswith("sample_1_")]
-    sample_2_fields = [field for field in variant_fields + derived_fields if field.startswith("sample_2_")]
-    ordered_variant_fields = context_fields + sample_1_fields + sample_2_fields + ["qc_warnings"]
-    with tempfile.NamedTemporaryFile("w", newline="", dir=variants_path.parent, delete=False) as temporary:
-        writer = csv.DictWriter(temporary, fieldnames=ordered_variant_fields, delimiter="\t")
+    sample_1_fields = [
+        field
+        for field in variant_fields + derived_fields
+        if field.startswith("sample_1_")
+    ]
+    sample_2_fields = [
+        field
+        for field in variant_fields + derived_fields
+        if field.startswith("sample_2_")
+    ]
+    ordered_variant_fields = (
+        context_fields + sample_1_fields + sample_2_fields + ["qc_warnings"]
+    )
+    with tempfile.NamedTemporaryFile(
+        "w", newline="", dir=variants_path.parent, delete=False
+    ) as temporary:
+        writer = csv.DictWriter(
+            temporary, fieldnames=ordered_variant_fields, delimiter="\t"
+        )
         writer.writeheader()
         writer.writerows(variant_rows)
         temporary_path = Path(temporary.name)
@@ -779,9 +811,19 @@ def enhance_output_tables(pairs_path: Path, variants_path: Path, threshold: int)
 def write_variant_summary(path: Path, rows: list[dict[str, str]]) -> None:
     """Write one concise, report-oriented row per pair-specific SNP"""
     fields = [
-        "pair_id", "sample_1", "sample_2", "snp_distance", "chrom", "pos", "core_ref",
-        "sample_1_call", "sample_2_call", "sample_1_evidence_summary",
-        "sample_2_evidence_summary", "removed_by_gubbins", "pair_clustered_snp",
+        "pair_id",
+        "sample_1",
+        "sample_2",
+        "snp_distance",
+        "chrom",
+        "pos",
+        "core_ref",
+        "sample_1_call",
+        "sample_2_call",
+        "sample_1_evidence_summary",
+        "sample_2_evidence_summary",
+        "removed_by_gubbins",
+        "pair_clustered_snp",
     ]
     with path.open("w", newline="") as handle:
         writer = csv.DictWriter(handle, fieldnames=fields, delimiter="\t")
@@ -796,31 +838,91 @@ def column_description(column: str) -> tuple[str, str]:
     to make column interpretation easier.
     """
     definitions = {
-        "pair_id": ("Generated as pair_0001, pair_0002, … in ascending distance order.", "Identifier linking a pair row to its SNP-variant rows."),
+        "pair_id": (
+            "Generated as pair_0001, pair_0002, … in ascending distance order.",
+            "Identifier linking a pair row to its SNP-variant rows.",
+        ),
         "sample_1": ("Sample-name column in core.tab.", "First sample in the pair."),
         "sample_2": ("Sample-name column in core.tab.", "Second sample in the pair."),
-        "snp_distance": ("Calculated from core.tab calls.", "Number of different A/C/G/T calls between the two samples."),
-        "comparable_core_sites": ("Calculated from core.tab calls.", "Positions where both samples have A, C, G or T and can be compared."),
-        "ignored_non_acgt_sites": ("Calculated from core.tab calls.", "Positions excluded because at least one call is not A, C, G or T."),
-        "core_tab_matrix_distance": ("core_tab_snp_distances.tsv: matrix cell for this pair.", "Distance independently calculated from core.tab, when the matrix is available."),
-        "core_tab_matrix_matches": ("Comparison of snp_distance and core_tab_matrix_distance.", "yes when both distances agree; no when they differ."),
-        "phylo_aln_distance": ("phylo_snp_distances.tsv: matrix cell for this pair.", "Distance in the phylogenetic alignment, when available."),
-        "phylo_matches_core_tab": ("Comparison of snp_distance and phylo_aln_distance.", "yes when both distances agree; no when they differ."),
-        "clean_core_aln_distance": ("clean_core_snp_distances.tsv: matrix cell for this pair.", "Distance after the clean/Gubbins-associated alignment, when available."),
-        "snps_removed_by_gubbins": ("snp_distance − clean_core_aln_distance.", "Differences no longer contributing to the clean-alignment distance."),
-        "clean_distance_valid": ("Comparison of clean_core_aln_distance and snp_distance.", "yes when the clean distance is not greater than the original distance."),
-        "distance_comparison_warnings": ("Calculated from the three distance-matrix comparisons.", "Semicolon-separated matrix discrepancies or missing-matrix warnings."),
-        "comparable_core_fraction": ("comparable_core_sites / (comparable_core_sites + ignored_non_acgt_sites).", "Fraction of core.tab positions usable for this pair."),
-        "matrix_availability": ("Presence of the three generated distance-matrix files.", "States whether core.tab, phylo and clean-core comparison matrices were available."),
+        "snp_distance": (
+            "Calculated from core.tab calls.",
+            "Number of different A/C/G/T calls between the two samples.",
+        ),
+        "comparable_core_sites": (
+            "Calculated from core.tab calls.",
+            "Positions where both samples have A, C, G or T and can be compared.",
+        ),
+        "ignored_non_acgt_sites": (
+            "Calculated from core.tab calls.",
+            "Positions excluded because at least one call is not A, C, G or T.",
+        ),
+        "core_tab_matrix_distance": (
+            "core_tab_snp_distances.tsv: matrix cell for this pair.",
+            "Distance independently calculated from core.tab, when the matrix is available.",
+        ),
+        "core_tab_matrix_matches": (
+            "Comparison of snp_distance and core_tab_matrix_distance.",
+            "yes when both distances agree; no when they differ.",
+        ),
+        "phylo_aln_distance": (
+            "phylo_snp_distances.tsv: matrix cell for this pair.",
+            "Distance in the phylogenetic alignment, when available.",
+        ),
+        "phylo_matches_core_tab": (
+            "Comparison of snp_distance and phylo_aln_distance.",
+            "yes when both distances agree; no when they differ.",
+        ),
+        "clean_core_aln_distance": (
+            "clean_core_snp_distances.tsv: matrix cell for this pair.",
+            "Distance after the clean/Gubbins-associated alignment, when available.",
+        ),
+        "snps_removed_by_gubbins": (
+            "snp_distance − clean_core_aln_distance.",
+            "Differences no longer contributing to the clean-alignment distance.",
+        ),
+        "clean_distance_valid": (
+            "Comparison of clean_core_aln_distance and snp_distance.",
+            "yes when the clean distance is not greater than the original distance.",
+        ),
+        "distance_comparison_warnings": (
+            "Calculated from the three distance-matrix comparisons.",
+            "Semicolon-separated matrix discrepancies or missing-matrix warnings.",
+        ),
+        "comparable_core_fraction": (
+            "comparable_core_sites / (comparable_core_sites + ignored_non_acgt_sites).",
+            "Fraction of core.tab positions usable for this pair.",
+        ),
+        "matrix_availability": (
+            "Presence of the three generated distance-matrix files.",
+            "States whether core.tab, phylo and clean-core comparison matrices were available.",
+        ),
         "chrom": ("core.tab: CHR.", "Chromosome identifier."),
         "pos": ("core.tab: POS.", "Genomic coordinate."),
         "core_ref": ("core.tab: REF.", "Reference base in core.tab."),
-        "sample_1_call": ("core.tab: sample_1 column at this position.", "Base called for sample_1."),
-        "sample_2_call": ("core.tab: sample_2 column at this position.", "Base called for sample_2."),
-        "pair_local_snp_count": ("Other differential core.tab sites for this pair within ±--cluster-window bp.", "Number of pair-specific SNPs in the local window, including this SNP."),
-        "pair_clustered_snp": ("pair_local_snp_count compared with --cluster-min-snps.", "yes when this SNP belongs to a local SNP cluster."),
-        "removed_by_gubbins": ("gubbins.recombination_predictions.gff coordinates.", "yes when the SNP lies in a predicted recombinant interval; only calculated automatically for a single-contig core.tab."),
-        "qc_warnings": ("QC checks on this row's VCF/BAM evidence and context.", "Semicolon-separated flags; they request review and do not remove the row."),
+        "sample_1_call": (
+            "core.tab: sample_1 column at this position.",
+            "Base called for sample_1.",
+        ),
+        "sample_2_call": (
+            "core.tab: sample_2 column at this position.",
+            "Base called for sample_2.",
+        ),
+        "pair_local_snp_count": (
+            "Other differential core.tab sites for this pair within ±--cluster-window bp.",
+            "Number of pair-specific SNPs in the local window, including this SNP.",
+        ),
+        "pair_clustered_snp": (
+            "pair_local_snp_count compared with --cluster-min-snps.",
+            "yes when this SNP belongs to a local SNP cluster.",
+        ),
+        "removed_by_gubbins": (
+            "gubbins.recombination_predictions.gff coordinates.",
+            "yes when the SNP lies in a predicted recombinant interval; only calculated automatically for a single-contig core.tab.",
+        ),
+        "qc_warnings": (
+            "QC checks on this row's VCF/BAM evidence and context.",
+            "Semicolon-separated flags; they request review and do not remove the row.",
+        ),
     }
     if column in definitions:
         return definitions[column]
@@ -828,40 +930,115 @@ def column_description(column: str) -> tuple[str, str]:
         prefix = f"sample_{number}_"
         if not column.startswith(prefix):
             continue
-        suffix = column[len(prefix):]
+        suffix = column[len(prefix) :]
         sample_label = f"sample_{number}"
         evidence = {
-            "evidence_status": ("VCF/BAM lookup result.", "How evidence was obtained: variant_record, reference_call_mpileup, or a missing-evidence status."),
-            "evidence_availability": ("evidence_status.", "available when VCF or BAM evidence was obtained; missing otherwise."),
-            "vcf_record_pos": ("snps.vcf: POS.", "Position of the supporting VCF record; blank for BAM-derived reference evidence."),
-            "vcf_ref": ("snps.vcf: REF; for BAM reference evidence, core_ref.", "Reference allele of the supporting record."),
-            "vcf_alt": ("snps.vcf: ALT; for BAM reference evidence, the other sample's call.", "Alternate allele associated with the comparison."),
+            "evidence_status": (
+                "VCF/BAM lookup result.",
+                "How evidence was obtained: variant_record, reference_call_mpileup, or a missing-evidence status.",
+            ),
+            "evidence_availability": (
+                "evidence_status.",
+                "available when VCF or BAM evidence was obtained; missing otherwise.",
+            ),
+            "vcf_record_pos": (
+                "snps.vcf: POS.",
+                "Position of the supporting VCF record; blank for BAM-derived reference evidence.",
+            ),
+            "vcf_ref": (
+                "snps.vcf: REF; for BAM reference evidence, core_ref.",
+                "Reference allele of the supporting record.",
+            ),
+            "vcf_alt": (
+                "snps.vcf: ALT; for BAM reference evidence, the other sample's call.",
+                "Alternate allele associated with the comparison.",
+            ),
             "qual": ("snps.vcf: QUAL.", "Variant quality reported by the caller."),
-            "filter": ("snps.vcf: FILTER.", "VCF filter status reported by the caller."),
+            "filter": (
+                "snps.vcf: FILTER.",
+                "VCF filter status reported by the caller.",
+            ),
             "genotype": ("snps.vcf: FORMAT/GT.", "Genotype recorded for this sample."),
-            "depth": ("snps.vcf: FORMAT/DP, otherwise INFO/DP; BAM reference evidence: mpileup depth.", "Total read depth used for allele fractions."),
-            "ref_count": ("snps.vcf: FORMAT/RO, otherwise INFO/RO; BAM reference evidence: parsed mpileup reference bases.", "Reads supporting the reference allele."),
-            "alt_count": ("snps.vcf: FORMAT/AO, otherwise INFO/AO; BAM reference evidence: parsed mpileup bases matching the other sample's call.", "Reads supporting the alternate allele."),
-            "variant_type": ("snps.vcf: INFO/TYPE; BAM reference evidence: reference_call.", "Variant type reported by the caller or reference-call label."),
-            "ref_forward_count": ("snps.raw.vcf: INFO/SRF; BAM reference evidence: parsed mpileup forward bases.", "Reference-supporting reads on the forward strand."),
-            "ref_reverse_count": ("snps.raw.vcf: INFO/SRR; BAM reference evidence: parsed mpileup reverse bases.", "Reference-supporting reads on the reverse strand."),
-            "alt_forward_count": ("snps.raw.vcf: INFO/SAF; BAM reference evidence: parsed mpileup forward bases.", "Alternate-supporting reads on the forward strand."),
-            "alt_reverse_count": ("snps.raw.vcf: INFO/SAR; BAM reference evidence: parsed mpileup reverse bases.", "Alternate-supporting reads on the reverse strand."),
-            "homopolymer_run": ("snps.raw.vcf: INFO/RUN.", "Homopolymer run length reported by FreeBayes."),
-            "nearest_indel_distance": ("snps.raw.vcf: positions with INFO/TYPE other than snp.", "Distance in bases to the nearest raw indel or complex call."),
-            "ref_fraction": ("ref_count / depth.", "Fraction of depth supporting the reference allele."),
-            "alt_fraction": ("alt_count / depth.", "Fraction of depth supporting the alternate allele."),
-            "called_allele": (f"core.tab: {sample_label} call.", "The base called for this sample at this SNP."),
-            "called_allele_count": ("ref_count when called_allele equals core_ref; otherwise alt_count.", "Read count supporting the called allele."),
-            "called_allele_fraction": ("called_allele_count / depth.", "Fraction of depth supporting the allele called in core.tab."),
-            "called_allele_forward_count": ("Reference or alternate forward count selected according to called_allele.", "Called-allele reads on the forward strand."),
-            "called_allele_reverse_count": ("Reference or alternate reverse count selected according to called_allele.", "Called-allele reads on the reverse strand."),
-            "called_allele_minor_strand_fraction": ("If the core.tab call equals core_ref: min(ref_forward_count, ref_reverse_count) / (ref_forward_count + ref_reverse_count); otherwise the same formula using alt_forward_count and alt_reverse_count.", "Fraction of called-allele reads on the less represented strand; lower values indicate stronger strand imbalance."),
-            "evidence_summary": ("Called-allele count, depth, fraction and strand counts above.", "Human-readable evidence summary for this sample and SNP."),
+            "depth": (
+                "snps.vcf: FORMAT/DP, otherwise INFO/DP; BAM reference evidence: mpileup depth.",
+                "Total read depth used for allele fractions.",
+            ),
+            "ref_count": (
+                "snps.vcf: FORMAT/RO, otherwise INFO/RO; BAM reference evidence: parsed mpileup reference bases.",
+                "Reads supporting the reference allele.",
+            ),
+            "alt_count": (
+                "snps.vcf: FORMAT/AO, otherwise INFO/AO; BAM reference evidence: parsed mpileup bases matching the other sample's call.",
+                "Reads supporting the alternate allele.",
+            ),
+            "variant_type": (
+                "snps.vcf: INFO/TYPE; BAM reference evidence: reference_call.",
+                "Variant type reported by the caller or reference-call label.",
+            ),
+            "ref_forward_count": (
+                "snps.raw.vcf: INFO/SRF; BAM reference evidence: parsed mpileup forward bases.",
+                "Reference-supporting reads on the forward strand.",
+            ),
+            "ref_reverse_count": (
+                "snps.raw.vcf: INFO/SRR; BAM reference evidence: parsed mpileup reverse bases.",
+                "Reference-supporting reads on the reverse strand.",
+            ),
+            "alt_forward_count": (
+                "snps.raw.vcf: INFO/SAF; BAM reference evidence: parsed mpileup forward bases.",
+                "Alternate-supporting reads on the forward strand.",
+            ),
+            "alt_reverse_count": (
+                "snps.raw.vcf: INFO/SAR; BAM reference evidence: parsed mpileup reverse bases.",
+                "Alternate-supporting reads on the reverse strand.",
+            ),
+            "homopolymer_run": (
+                "snps.raw.vcf: INFO/RUN.",
+                "Homopolymer run length reported by FreeBayes.",
+            ),
+            "nearest_indel_distance": (
+                "snps.raw.vcf: positions with INFO/TYPE other than snp.",
+                "Distance in bases to the nearest raw indel or complex call.",
+            ),
+            "ref_fraction": (
+                "ref_count / depth.",
+                "Fraction of depth supporting the reference allele.",
+            ),
+            "alt_fraction": (
+                "alt_count / depth.",
+                "Fraction of depth supporting the alternate allele.",
+            ),
+            "called_allele": (
+                f"core.tab: {sample_label} call.",
+                "The base called for this sample at this SNP.",
+            ),
+            "called_allele_count": (
+                "ref_count when called_allele equals core_ref; otherwise alt_count.",
+                "Read count supporting the called allele.",
+            ),
+            "called_allele_fraction": (
+                "called_allele_count / depth.",
+                "Fraction of depth supporting the allele called in core.tab.",
+            ),
+            "called_allele_forward_count": (
+                "Reference or alternate forward count selected according to called_allele.",
+                "Called-allele reads on the forward strand.",
+            ),
+            "called_allele_reverse_count": (
+                "Reference or alternate reverse count selected according to called_allele.",
+                "Called-allele reads on the reverse strand.",
+            ),
+            "called_allele_minor_strand_fraction": (
+                "If the core.tab call equals core_ref: min(ref_forward_count, ref_reverse_count) / (ref_forward_count + ref_reverse_count); otherwise the same formula using alt_forward_count and alt_reverse_count.",
+                "Fraction of called-allele reads on the less represented strand; lower values indicate stronger strand imbalance.",
+            ),
+            "evidence_summary": (
+                "Called-allele count, depth, fraction and strand counts above.",
+                "Human-readable evidence summary for this sample and SNP.",
+            ),
         }
         if suffix in evidence:
             return evidence[suffix]
-    return ("Column descriptions generated!")
+    return "Column descriptions generated!"
 
 
 def build_data_dictionary_rows(
@@ -888,7 +1065,6 @@ def build_data_dictionary_rows(
     return rows
 
 
-
 def read_tsv_rows(path: Path) -> tuple[list[str], list[dict[str, str]]]:
     """Read a result TSV preserving its header order for a summary Excel worksheet"""
     with path.open(newline="") as handle:
@@ -896,32 +1072,51 @@ def read_tsv_rows(path: Path) -> tuple[list[str], list[dict[str, str]]]:
         return list(reader.fieldnames or []), list(reader)
 
 
-
 def excel_cell_value(header: str, value: str) -> int | float | str:
     """
     Convert quantitative result columns to Excel numbers to avoid issues when opening such file
     """
     numeric_columns = {
-        "pos", "snp_distance", "comparable_core_sites", "ignored_non_acgt_sites",
-        "core_tab_matrix_distance", "phylo_aln_distance", "clean_core_aln_distance",
-        "snps_removed_by_gubbins", "comparable_core_fraction", "pair_local_snp_count",
+        "pos",
+        "snp_distance",
+        "comparable_core_sites",
+        "ignored_non_acgt_sites",
+        "core_tab_matrix_distance",
+        "phylo_aln_distance",
+        "clean_core_aln_distance",
+        "snps_removed_by_gubbins",
+        "comparable_core_fraction",
+        "pair_local_snp_count",
     }
     numeric_suffixes = (
-        "_vcf_record_pos", "_qual", "_depth", "_ref_count", "_alt_count",
-        "_ref_forward_count", "_ref_reverse_count", "_alt_forward_count",
-        "_alt_reverse_count", "_homopolymer_run", "_nearest_indel_distance",
-        "_ref_fraction", "_alt_fraction", "_called_allele_count",
-        "_called_allele_fraction", "_called_allele_forward_count",
-        "_called_allele_reverse_count", "_called_allele_minor_strand_fraction",
+        "_vcf_record_pos",
+        "_qual",
+        "_depth",
+        "_ref_count",
+        "_alt_count",
+        "_ref_forward_count",
+        "_ref_reverse_count",
+        "_alt_forward_count",
+        "_alt_reverse_count",
+        "_homopolymer_run",
+        "_nearest_indel_distance",
+        "_ref_fraction",
+        "_alt_fraction",
+        "_called_allele_count",
+        "_called_allele_fraction",
+        "_called_allele_forward_count",
+        "_called_allele_reverse_count",
+        "_called_allele_minor_strand_fraction",
     )
-    if value in ("", "not_available") or (header not in numeric_columns and not header.endswith(numeric_suffixes)):
+    if value in ("", "not_available") or (
+        header not in numeric_columns and not header.endswith(numeric_suffixes)
+    ):
         return value
     try:
         numeric_value = float(value)
     except ValueError:
         return value
     return int(numeric_value) if numeric_value.is_integer() else numeric_value
-
 
 
 def style_table_worksheet(ws, headers: list[str], rows: list[dict[str, str]]) -> None:
@@ -944,10 +1139,16 @@ def style_table_worksheet(ws, headers: list[str], rows: list[dict[str, str]]) ->
             cell.alignment = Alignment(wrap_text=True, vertical="top")
     if headers:
         ws.freeze_panes = "A2"
-        ws.auto_filter.ref = f"A1:{get_column_letter(len(headers))}{max(1, len(rows) + 1)}"
+        ws.auto_filter.ref = (
+            f"A1:{get_column_letter(len(headers))}{max(1, len(rows) + 1)}"
+        )
         for column, header in enumerate(headers, start=1):
-            longest = max([len(header)] + [len(str(row.get(header, ""))) for row in rows])
-            ws.column_dimensions[get_column_letter(column)].width = min(max(longest + 2, 12), 45)
+            longest = max(
+                [len(header)] + [len(str(row.get(header, ""))) for row in rows]
+            )
+            ws.column_dimensions[get_column_letter(column)].width = min(
+                max(longest + 2, 12), 45
+            )
 
 
 def write_excel_report(
@@ -990,12 +1191,32 @@ def write_excel_report(
         cell.fill = section_fill
     sheet_entries = [
         ("README", "This index of the workbook sheets.", "Start here."),
-        ("Close pairs", "One row per pair of samples retained below the requested SNP threshold.", "Use it to identify close pairs and inspect distance-matrix consistency."),
-        ("SNP variants", "One technical row for each SNP that differs within a retained pair.", "Use it for detailed VCF, BAM and QC evidence."),
+        (
+            "Close pairs",
+            "One row per pair of samples retained below the requested SNP threshold.",
+            "Use it to identify close pairs and inspect distance-matrix consistency.",
+        ),
+        (
+            "SNP variants",
+            "One technical row for each SNP that differs within a retained pair.",
+            "Use it for detailed VCF, BAM and QC evidence.",
+        ),
     ]
     if summary_path is not None:
-        sheet_entries.append(("Variant summary", "A compact version of the SNP-variant table.", "Use it for manual evaluation; consult SNP variants sheet to check all fields."))
-    sheet_entries.append(("Column descriptions", "Definition and exact source field or calculation for every output column.", "Check this sheet to find the meaning of each column field."))
+        sheet_entries.append(
+            (
+                "Variant summary",
+                "A compact version of the SNP-variant table.",
+                "Use it for manual evaluation; consult SNP variants sheet to check all fields.",
+            )
+        )
+    sheet_entries.append(
+        (
+            "Column descriptions",
+            "Definition and exact source field or calculation for every output column.",
+            "Check this sheet to find the meaning of each column field.",
+        )
+    )
     for entry in sheet_entries:
         readme.append(entry)
     for row in readme.iter_rows():
@@ -1024,7 +1245,6 @@ def write_excel_report(
     workbook.save(path)
 
 
-
 def sha256_file(path: Path) -> str | None:
     """Return a content hash for a present input file, otherwise ``None``."""
     if not path.is_file():
@@ -1036,7 +1256,15 @@ def sha256_file(path: Path) -> str | None:
     return digest.hexdigest()
 
 
-def write_metadata(path: Path, args: argparse.Namespace, core_tab: Path, pairs_path: Path, variants_path: Path, summary_path: Path | None, excel_path: Path | None) -> None:
+def write_metadata(
+    path: Path,
+    args: argparse.Namespace,
+    core_tab: Path,
+    pairs_path: Path,
+    variants_path: Path,
+    summary_path: Path | None,
+    excel_path: Path | None,
+) -> None:
     """Write provenance sufficient to interpret and reproduce a result table."""
     metadata = {
         "script": "evaluate_close_pairs.py",
@@ -1046,8 +1274,12 @@ def write_metadata(path: Path, args: argparse.Namespace, core_tab: Path, pairs_p
             key: str(value.resolve()) if isinstance(value, Path) else value
             for key, value in vars(args).items()
         },
-        "inputs": {"core_tab": {"path": str(core_tab), "sha256": sha256_file(core_tab)}},
-        "outputs": [str(pairs_path), str(variants_path)] + ([str(summary_path)] if summary_path else []) + ([str(excel_path)] if excel_path else []),
+        "inputs": {
+            "core_tab": {"path": str(core_tab), "sha256": sha256_file(core_tab)}
+        },
+        "outputs": [str(pairs_path), str(variants_path)]
+        + ([str(summary_path)] if summary_path else [])
+        + ([str(excel_path)] if excel_path else []),
     }
     path.write_text(json.dumps(metadata, indent=2) + "\n")
 
@@ -1379,8 +1611,13 @@ def main() -> int:
             excel_path = Path.cwd() / excel_path
         try:
             write_excel_report(
-                excel_path, pairs_path, variants_path, summary_path,
-                args, len(samples), len(sites),
+                excel_path,
+                pairs_path,
+                variants_path,
+                summary_path,
+                args,
+                len(samples),
+                len(sites),
             )
         except RuntimeError as error:
             print(f"WARNING: {error}", file=sys.stderr)
@@ -1388,7 +1625,15 @@ def main() -> int:
     metadata_path = None
     if not args.no_metadata:
         metadata_path = prefix.with_name(prefix.name + "_metadata.json")
-        write_metadata(metadata_path, args, core_tab, pairs_path, variants_path, summary_path, excel_path)
+        write_metadata(
+            metadata_path,
+            args,
+            core_tab,
+            pairs_path,
+            variants_path,
+            summary_path,
+            excel_path,
+        )
 
     variant_count = sum(len(pair["differences"]) for pair in pairs)
     print(f"Samples: {len(samples)}")

--- a/buisciii/templates/snippy/ANALYSIS/ANALYSIS01_SNIPPY/05-snippy/evaluate_close_pairs.py
+++ b/buisciii/templates/snippy/ANALYSIS/ANALYSIS01_SNIPPY/05-snippy/evaluate_close_pairs.py
@@ -711,18 +711,11 @@ def annotate_variant_row(row: dict[str, str]) -> dict[str, str]:
                 f"{call}: {format_number(count)}/{format_number(row.get(f'{prefix}_depth', ''))} "
                 f"({format_fraction(fraction)}); strands {format_number(forward)}/{format_number(reverse)}"
             )
-    warnings = row.get("qc_warnings", "")
-    row["qc_status"] = "PASS" if not warnings else "REVIEW"
-    row["review_reasons"] = warnings or "none"
     return row
 
 
 def enhance_output_tables(pairs_path: Path, variants_path: Path, threshold: int) -> list[dict[str, str]]:
     """Include additional useful interpretation fields to the TSV output files"""
-    pair_extra = [
-        "pair_selection_rule", "comparable_core_fraction", "matrix_availability",
-        "pair_qc_status", "pair_review_reasons",
-    ]
     with pairs_path.open(newline="") as handle:
         reader = csv.DictReader(handle, delimiter="\t")
         pair_rows = list(reader)
@@ -731,7 +724,6 @@ def enhance_output_tables(pairs_path: Path, variants_path: Path, threshold: int)
         comparable = as_float(row.get("comparable_core_sites")) or 0
         ignored = as_float(row.get("ignored_non_acgt_sites")) or 0
         total = comparable + ignored
-        row["pair_selection_rule"] = f"snp_distance < {threshold}"
         row["comparable_core_fraction"] = "" if total == 0 else str(comparable / total)
         missing = [
             label for label, field in (
@@ -741,11 +733,17 @@ def enhance_output_tables(pairs_path: Path, variants_path: Path, threshold: int)
             ) if not row.get(field, "")
         ]
         row["matrix_availability"] = "all_available" if not missing else "missing:" + ",".join(missing)
-        warnings = row.get("distance_comparison_warnings", "")
-        row["pair_qc_status"] = "PASS" if not warnings else "REVIEW"
-        row["pair_review_reasons"] = warnings or "none"
+    ordered_pair_fields = []
+    for field in pair_fields:
+        ordered_pair_fields.append(field)
+
+        if field == "ignored_non_acgt_sites":
+            ordered_pair_fields.append("comparable_core_fraction")
+
+        if field == "snps_removed_by_gubbins":
+            ordered_pair_fields.append("matrix_availability")
     with tempfile.NamedTemporaryFile("w", newline="", dir=pairs_path.parent, delete=False) as temporary:
-        writer = csv.DictWriter(temporary, fieldnames=pair_fields + pair_extra, delimiter="\t")
+        writer = csv.DictWriter(temporary, fieldnames=ordered_pair_fields, delimiter="\t")
         writer.writeheader()
         writer.writerows(pair_rows)
         temporary_path = Path(temporary.name)
@@ -760,7 +758,7 @@ def enhance_output_tables(pairs_path: Path, variants_path: Path, threshold: int)
             f"sample_{number}_called_allele_minor_strand_fraction",
             f"sample_{number}_evidence_summary",
         )
-    ] + ["qc_status", "review_reasons"]
+    ]
     context_fields = [
         field for field in variant_fields
         if (not field.startswith("sample_") or field in ("sample_1", "sample_2"))
@@ -768,8 +766,7 @@ def enhance_output_tables(pairs_path: Path, variants_path: Path, threshold: int)
     ]
     sample_1_fields = [field for field in variant_fields + derived_fields if field.startswith("sample_1_")]
     sample_2_fields = [field for field in variant_fields + derived_fields if field.startswith("sample_2_")]
-    qc_fields = ["qc_warnings", "qc_status", "review_reasons"]
-    ordered_variant_fields = context_fields + sample_1_fields + sample_2_fields + qc_fields
+    ordered_variant_fields = context_fields + sample_1_fields + sample_2_fields + ["qc_warnings"]
     with tempfile.NamedTemporaryFile("w", newline="", dir=variants_path.parent, delete=False) as temporary:
         writer = csv.DictWriter(temporary, fieldnames=ordered_variant_fields, delimiter="\t")
         writer.writeheader()
@@ -785,7 +782,6 @@ def write_variant_summary(path: Path, rows: list[dict[str, str]]) -> None:
         "pair_id", "sample_1", "sample_2", "snp_distance", "chrom", "pos", "core_ref",
         "sample_1_call", "sample_2_call", "sample_1_evidence_summary",
         "sample_2_evidence_summary", "removed_by_gubbins", "pair_clustered_snp",
-        "qc_status", "review_reasons",
     ]
     with path.open("w", newline="") as handle:
         writer = csv.DictWriter(handle, fieldnames=fields, delimiter="\t")
@@ -814,11 +810,8 @@ def column_description(column: str) -> tuple[str, str]:
         "snps_removed_by_gubbins": ("snp_distance − clean_core_aln_distance.", "Differences no longer contributing to the clean-alignment distance."),
         "clean_distance_valid": ("Comparison of clean_core_aln_distance and snp_distance.", "yes when the clean distance is not greater than the original distance."),
         "distance_comparison_warnings": ("Calculated from the three distance-matrix comparisons.", "Semicolon-separated matrix discrepancies or missing-matrix warnings."),
-        "pair_selection_rule": ("Command-line parameter --threshold.", "Strict rule used to retain this pair."),
         "comparable_core_fraction": ("comparable_core_sites / (comparable_core_sites + ignored_non_acgt_sites).", "Fraction of core.tab positions usable for this pair."),
         "matrix_availability": ("Presence of the three generated distance-matrix files.", "States whether core.tab, phylo and clean-core comparison matrices were available."),
-        "pair_qc_status": ("distance_comparison_warnings.", "PASS when no pair-level matrix warning exists; REVIEW otherwise."),
-        "pair_review_reasons": ("distance_comparison_warnings.", "Pair-level warnings, or none."),
         "chrom": ("core.tab: CHR.", "Chromosome identifier."),
         "pos": ("core.tab: POS.", "Genomic coordinate."),
         "core_ref": ("core.tab: REF.", "Reference base in core.tab."),
@@ -828,8 +821,6 @@ def column_description(column: str) -> tuple[str, str]:
         "pair_clustered_snp": ("pair_local_snp_count compared with --cluster-min-snps.", "yes when this SNP belongs to a local SNP cluster."),
         "removed_by_gubbins": ("gubbins.recombination_predictions.gff coordinates.", "yes when the SNP lies in a predicted recombinant interval; only calculated automatically for a single-contig core.tab."),
         "qc_warnings": ("QC checks on this row's VCF/BAM evidence and context.", "Semicolon-separated flags; they request review and do not remove the row."),
-        "qc_status": ("qc_warnings.", "PASS when no QC flags were raised; REVIEW otherwise."),
-        "review_reasons": ("qc_warnings.", "QC flags for this SNP, or none."),
     }
     if column in definitions:
         return definitions[column]

--- a/buisciii/templates/snippy/ANALYSIS/ANALYSIS01_SNIPPY/05-snippy/evaluate_close_pairs.py
+++ b/buisciii/templates/snippy/ANALYSIS/ANALYSIS01_SNIPPY/05-snippy/evaluate_close_pairs.py
@@ -12,17 +12,21 @@ from __future__ import annotations
 import argparse
 import csv
 import gzip
+import hashlib
 import itertools
+import json
 import shutil
 import subprocess
 import sys
 import tempfile
+from datetime import datetime, timezone
 from pathlib import Path
 
 VALID_BASES = frozenset("ACGT")
 
 
 def parse_args() -> argparse.Namespace:
+    """Parse command-line options for the close-pair SNP QC workflow."""
     parser = argparse.ArgumentParser(
         description=(
             "Calculate pairwise SNP distances from core.tab and extract VCF "
@@ -45,18 +49,18 @@ def parse_args() -> argparse.Namespace:
         "--threshold",
         type=int,
         default=20,
-        help="retain pairs with fewer than this many SNPs (default: 20)",
+        help="Retain pairs with fewer than this many SNPs (default: 20)",
     )
     parser.add_argument(
         "--output-prefix",
         type=Path,
         default=Path("close_pair_snp_qc"),
-        help="output path prefix (default: close_pair_snp_qc)",
+        help="Output file prefix (default: close_pair_snp_qc)",
     )
     parser.add_argument(
         "--matrices-dir",
         type=Path,
-        help="directory containing generated SNP-distance matrices (default: SNIPPY_DIR)",
+        help="Directory containing generated SNP-distance matrices (default: SNIPPY_DIR)",
     )
     parser.add_argument(
         "--gubbins-gff",
@@ -67,81 +71,107 @@ def parse_args() -> argparse.Namespace:
         "--missing-vcf",
         choices=("error", "warn"),
         default="error",
-        help="action when a selected sample has no VCF (default: error)",
+        help="Action to perform when a selected sample has no VCF (default: error)",
     )
     parser.add_argument(
         "--reference",
         type=Path,
-        help="reference FASTA override for mpileup (default: each sample's reference/ref.fa)",
+        help="Reference FASTA override for mpileup (default: each sample's reference/ref.fa)",
     )
     parser.add_argument(
         "--samtools",
         default="samtools",
-        help="samtools executable or path (default: samtools)",
+        help="Samtools executable or path (default: samtools)",
     )
     parser.add_argument(
         "--no-bam-evidence",
         action="store_true",
-        help="do not obtain evidence for reference calls from snps.bam",
+        help="Do not obtain evidence for reference calls from snps.bam",
     )
     parser.add_argument(
         "--pileup-mapq",
         type=int,
         default=10,
-        help="minimum mapping quality for mpileup evidence (default: 10)",
+        help="Minimum mapping quality for mpileup evidence (default: 10)",
     )
     parser.add_argument(
         "--pileup-baseq",
         type=int,
         default=5,
-        help="minimum base quality for mpileup evidence (default: 5)",
+        help="Minimum base quality for mpileup evidence (default: 5)",
     )
     parser.add_argument(
         "--warn-min-depth",
         type=float,
         default=10,
-        help="warn when evidence depth is below this value (default: 10)",
+        help="Warn when evidence depth is below this value (default: 10)",
     )
     parser.add_argument(
         "--warn-min-called-fraction",
         type=float,
         default=0.90,
-        help="warn when the called allele fraction is below this value (default: 0.90)",
+        help="Warn when the called allele fraction is below this value (default: 0.90)",
     )
     parser.add_argument(
         "--no-qc-warnings",
         action="store_true",
-        help="suppress per-site QC warnings on standard output",
+        help="Suppress per-site QC warnings on standard output",
     )
     parser.add_argument(
         "--warn-min-strand-fraction",
         type=float,
         default=0.10,
-        help="warn if less than this fraction of called reads is on either strand (default: 0.10)",
+        help="Warn if less than this fraction of called reads is on either strand (default: 0.10)",
     )
     parser.add_argument(
         "--warn-indel-distance",
         type=int,
         default=5,
-        help="warn for SNPs within this many bases of a raw-VCF indel/complex call (default: 5)",
+        help="Warn for SNPs within these many bases of a raw-VCF indel/complex call (default: 5)",
     )
     parser.add_argument(
         "--warn-homopolymer-run",
         type=int,
         default=5,
-        help="warn when FreeBayes RUN is at least this length (default: 5)",
+        help="Warn when FreeBayes' RUN field is at least this length (default: 5)",
     )
     parser.add_argument(
         "--cluster-window",
         type=int,
         default=100,
-        help="window size in bases for local pairwise SNP clusters (default: 100)",
+        help="Window size in bases for local pairwise SNP clusters (default: 100)",
     )
     parser.add_argument(
         "--cluster-min-snps",
         type=int,
         default=3,
-        help="minimum pairwise SNPs in the window to flag a cluster (default: 3)",
+        help="Minimum pairwise SNPs in the window to flag a cluster (default: 3)",
+    )
+    parser.add_argument(
+        "--no-summary",
+        action="store_true",
+        help="Do not write the human-readable variant summary table",
+    )
+    parser.add_argument(
+        "--no-column-descriptions",
+        dest="no_data_dictionary",
+        action="store_true",
+        help="Do not write the TSV column descriptions",
+    )
+    parser.add_argument(
+        "--no-metadata",
+        action="store_true",
+        help="Do not write the JSON run metadata and provenance file",
+    )
+    parser.add_argument(
+        "--no-excel",
+        action="store_true",
+        help="Do not write the Excel report with README and result sheets",
+    )
+    parser.add_argument(
+        "--excel-output",
+        type=Path,
+        help="Excel report filename (default: OUTPUT_PREFIX_report.xlsx)",
     )
     return parser.parse_args()
 
@@ -149,6 +179,11 @@ def parse_args() -> argparse.Namespace:
 def read_core_tab(
     path: Path,
 ) -> tuple[list[str], list[tuple[str, int, str, list[str]]]]:
+    """Read core.tab without discarding non-canonical calls.
+
+    Calls are upper-cased.  Pairwise A/C/G/T filtering is deferred to the following
+    ``find_close_pairs`` function so that excluded positions can be reported.
+    """
     with path.open(newline="") as handle:
         reader = csv.reader(handle, delimiter="\t")
         try:
@@ -175,6 +210,11 @@ def read_core_tab(
 
 
 def find_close_pairs(samples, sites, threshold):
+    """Find pairs with strictly fewer than specified ``threshold`` comparable SNPs.
+
+    A site is comparable only when both calls are A/C/G/T; all other calls are
+    pairwise-deleted rather than treated as a match or a difference.
+    """
     results = []
     for left, right in itertools.combinations(range(len(samples)), 2):
         differences = []
@@ -205,6 +245,7 @@ def find_close_pairs(samples, sites, threshold):
 
 
 def read_distance_matrix(path: Path) -> dict[frozenset[str], int]:
+    """Read a symmetric TSV matrix and validate matching row/column order."""
     with path.open(newline="") as handle:
         reader = csv.reader(handle, delimiter="\t")
         try:
@@ -250,6 +291,7 @@ def read_gubbins_intervals(path: Path) -> list[tuple[int, int]]:
 
 
 def position_in_intervals(position: int, intervals: list[tuple[int, int]]) -> bool:
+    """Return whether a 1-based position lies in a merged inclusive interval"""
     import bisect
 
     starts = [start for start, _ in intervals]
@@ -258,10 +300,12 @@ def position_in_intervals(position: int, intervals: list[tuple[int, int]]) -> bo
 
 
 def open_text(path: Path):
+    """Open a plain-text or gzip-compressed file for text reading"""
     return gzip.open(path, "rt") if path.suffix == ".gz" else path.open()
 
 
 def parse_list(value: str, cast=int):
+    """Parse a comma-separated VCF value, retaining invalid items as ``None``."""
     if value in ("", "."):
         return []
     result = []
@@ -274,6 +318,7 @@ def parse_list(value: str, cast=int):
 
 
 def scalar_or_alt(value: str | None, alt_index: int):
+    """Select the value corresponding to one ALT allele from a VCF field"""
     if value in (None, "", "."):
         return ""
     values = value.split(",")
@@ -338,6 +383,7 @@ def read_vcf(path: Path) -> dict[tuple[str, int, str], dict[str, str]]:
 
 
 def locate_vcf(snippy_dir: Path, sample: str) -> Path | None:
+    """Locate a sample's filtered VCF, accepting plain or gzip-compressed files."""
     for name in ("snps.vcf", "snps.vcf.gz"):
         candidate = snippy_dir / sample / name
         if candidate.is_file():
@@ -346,6 +392,7 @@ def locate_vcf(snippy_dir: Path, sample: str) -> Path | None:
 
 
 def locate_raw_vcf(snippy_dir: Path, sample: str) -> Path | None:
+    """Locate a sample's raw VCF, accepting plain or gzip-compressed files."""
     for name in ("snps.raw.vcf", "snps.raw.vcf.gz"):
         candidate = snippy_dir / sample / name
         if candidate.is_file():
@@ -354,6 +401,7 @@ def locate_raw_vcf(snippy_dir: Path, sample: str) -> Path | None:
 
 
 def read_non_snp_positions(path: Path) -> dict[str, list[int]]:
+    """Find raw-VCF positions whose INFO/TYPE includes a non-SNP event."""
     positions: dict[str, list[int]] = {}
     with open_text(path) as handle:
         for line in handle:
@@ -374,6 +422,7 @@ def read_non_snp_positions(path: Path) -> dict[str, list[int]]:
 
 
 def nearest_distance(sorted_positions: list[int], position: int) -> int | None:
+    """Return the distance to the closest position in a sorted coordinate list."""
     import bisect
 
     index = bisect.bisect_left(sorted_positions, position)
@@ -420,6 +469,12 @@ def read_bam_pileup(
     minimum_mapq: int,
     minimum_baseq: int,
 ) -> dict[tuple[str, int], dict[str, object]]:
+    """Run ``samtools mpileup`` for selected 1-based sites.
+
+    Sites are written as 0-based half-open BED intervals. Mapping quality
+    (``-q``) and base quality (``-Q``) are applied before parsing A/C/G/T
+    support and strand orientation from the read-bases field.
+    """
     if not positions:
         return {}
     with tempfile.NamedTemporaryFile("w", suffix=".bed") as bed:
@@ -458,6 +513,7 @@ def read_bam_pileup(
 
 
 def evidence_for(index, bam_index, chrom, pos, core_ref, call, other_call):
+    """Select VCF evidence, BAM evidence for a reference call, or a status."""
     record = index.get((chrom, pos, call))
     if record is not None:
         return "variant_record", record
@@ -512,6 +568,7 @@ EVIDENCE_COLUMNS = (
 
 
 def add_fractions(row: dict[str, object], prefix: str) -> None:
+    """Calculate reference/alternate support fractions using total DP."""
     try:
         dp = float(row[f"{prefix}_depth"])
     except (ValueError, TypeError):
@@ -526,6 +583,7 @@ def add_fractions(row: dict[str, object], prefix: str) -> None:
 
 
 def numeric(value: object) -> float | None:
+    """Convert an evidence value to ``float``, or return ``None`` if unavailable."""
     try:
         return float(value)
     except (TypeError, ValueError):
@@ -541,6 +599,7 @@ def collect_qc_warnings(
     maximum_indel_distance: int,
     minimum_homopolymer_run: int,
 ) -> list[tuple[str, str]]:
+    """Return QC warnings for one sample at one SNP site."""
     prefix = f"sample_{sample_number}"
     sample = str(row[prefix])
     location = f"{row['chrom']}:{row['pos']}"
@@ -610,7 +669,396 @@ def collect_qc_warnings(
     return warnings
 
 
+
+def as_float(value: object) -> float | None:
+    """Return a numeric value, or ``None`` when an evidence field is absent."""
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def format_number(value: object) -> str:
+    """Format an evidence count without adding a misleading decimal point."""
+    numeric_value = as_float(value)
+    if numeric_value is None:
+        return "not_available"
+    return f"{numeric_value:g}"
+
+
+def format_fraction(value: object) -> str:
+    """Format a proportion for the human-readable evidence summary."""
+    numeric_value = as_float(value)
+    return "not_available" if numeric_value is None else f"{numeric_value:.1%}"
+
+
+def annotate_variant_row(row: dict[str, str]) -> dict[str, str]:
+    """Add interpretation-ready evidence fields without changing raw evidence"""
+    for number in (1, 2):
+        prefix = f"sample_{number}"
+        call = row[f"{prefix}_call"]
+        called_kind = "ref" if call == row["core_ref"] else "alt"
+        status = row.get(f"{prefix}_evidence_status", "")
+        count = row.get(f"{prefix}_{called_kind}_count", "")
+        fraction = row.get(f"{prefix}_{called_kind}_fraction", "")
+        forward = row.get(f"{prefix}_{called_kind}_forward_count", "")
+        reverse = row.get(f"{prefix}_{called_kind}_reverse_count", "")
+        forward_value, reverse_value = as_float(forward), as_float(reverse)
+        if forward_value is None or reverse_value is None or forward_value + reverse_value == 0:
+            minor_fraction = ""
+        else:
+            minor_fraction = str(min(forward_value, reverse_value) / (forward_value + reverse_value))
+        evidence_available = status in ("variant_record", "reference_call_mpileup")
+        row[f"{prefix}_called_allele_minor_strand_fraction"] = minor_fraction
+        if not evidence_available:
+            row[f"{prefix}_evidence_summary"] = f"{call}: evidence not available ({status})"
+        else:
+            row[f"{prefix}_evidence_summary"] = (
+                f"{call}: {format_number(count)}/{format_number(row.get(f'{prefix}_depth', ''))} "
+                f"({format_fraction(fraction)}); strands {format_number(forward)}/{format_number(reverse)}"
+            )
+    warnings = row.get("qc_warnings", "")
+    row["qc_status"] = "PASS" if not warnings else "REVIEW"
+    row["review_reasons"] = warnings or "none"
+    return row
+
+
+def enhance_output_tables(pairs_path: Path, variants_path: Path, threshold: int) -> list[dict[str, str]]:
+    """Include additional useful interpretation fields to the TSV output files"""
+    pair_extra = [
+        "pair_selection_rule", "comparable_core_fraction", "matrix_availability",
+        "pair_qc_status", "pair_review_reasons",
+    ]
+    with pairs_path.open(newline="") as handle:
+        reader = csv.DictReader(handle, delimiter="\t")
+        pair_rows = list(reader)
+        pair_fields = list(reader.fieldnames or [])
+    for row in pair_rows:
+        comparable = as_float(row.get("comparable_core_sites")) or 0
+        ignored = as_float(row.get("ignored_non_acgt_sites")) or 0
+        total = comparable + ignored
+        row["pair_selection_rule"] = f"snp_distance < {threshold}"
+        row["comparable_core_fraction"] = "" if total == 0 else str(comparable / total)
+        missing = [
+            label for label, field in (
+                ("core_tab", "core_tab_matrix_distance"),
+                ("phylo", "phylo_aln_distance"),
+                ("clean_core", "clean_core_aln_distance"),
+            ) if not row.get(field, "")
+        ]
+        row["matrix_availability"] = "all_available" if not missing else "missing:" + ",".join(missing)
+        warnings = row.get("distance_comparison_warnings", "")
+        row["pair_qc_status"] = "PASS" if not warnings else "REVIEW"
+        row["pair_review_reasons"] = warnings or "none"
+    with tempfile.NamedTemporaryFile("w", newline="", dir=pairs_path.parent, delete=False) as temporary:
+        writer = csv.DictWriter(temporary, fieldnames=pair_fields + pair_extra, delimiter="\t")
+        writer.writeheader()
+        writer.writerows(pair_rows)
+        temporary_path = Path(temporary.name)
+    temporary_path.replace(pairs_path)
+
+    with variants_path.open(newline="") as handle:
+        reader = csv.DictReader(handle, delimiter="\t")
+        variant_rows = [annotate_variant_row(dict(row)) for row in reader]
+        variant_fields = list(reader.fieldnames or [])
+    derived_fields = [
+        field for number in (1, 2) for field in (
+            f"sample_{number}_called_allele_minor_strand_fraction",
+            f"sample_{number}_evidence_summary",
+        )
+    ] + ["qc_status", "review_reasons"]
+    context_fields = [
+        field for field in variant_fields
+        if (not field.startswith("sample_") or field in ("sample_1", "sample_2"))
+        and field != "qc_warnings"
+    ]
+    sample_1_fields = [field for field in variant_fields + derived_fields if field.startswith("sample_1_")]
+    sample_2_fields = [field for field in variant_fields + derived_fields if field.startswith("sample_2_")]
+    qc_fields = ["qc_warnings", "qc_status", "review_reasons"]
+    ordered_variant_fields = context_fields + sample_1_fields + sample_2_fields + qc_fields
+    with tempfile.NamedTemporaryFile("w", newline="", dir=variants_path.parent, delete=False) as temporary:
+        writer = csv.DictWriter(temporary, fieldnames=ordered_variant_fields, delimiter="\t")
+        writer.writeheader()
+        writer.writerows(variant_rows)
+        temporary_path = Path(temporary.name)
+    temporary_path.replace(variants_path)
+    return variant_rows
+
+
+def write_variant_summary(path: Path, rows: list[dict[str, str]]) -> None:
+    """Write one concise, report-oriented row per pair-specific SNP"""
+    fields = [
+        "pair_id", "sample_1", "sample_2", "snp_distance", "chrom", "pos", "core_ref",
+        "sample_1_call", "sample_2_call", "sample_1_evidence_summary",
+        "sample_2_evidence_summary", "removed_by_gubbins", "pair_clustered_snp",
+        "qc_status", "review_reasons",
+    ]
+    with path.open("w", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fields, delimiter="\t")
+        writer.writeheader()
+        for row in rows:
+            writer.writerow({field: row.get(field, "") for field in fields})
+
+
+def column_description(column: str) -> tuple[str, str]:
+    """
+    Return a detailed source and definition explanation for every output field of the TSV output files,
+    to make column interpretation easier.
+    """
+    definitions = {
+        "pair_id": ("Generated as pair_0001, pair_0002, … in ascending distance order.", "Identifier linking a pair row to its SNP-variant rows."),
+        "sample_1": ("Sample-name column in core.tab.", "First sample in the pair."),
+        "sample_2": ("Sample-name column in core.tab.", "Second sample in the pair."),
+        "snp_distance": ("Calculated from core.tab calls.", "Number of different A/C/G/T calls between the two samples."),
+        "comparable_core_sites": ("Calculated from core.tab calls.", "Positions where both samples have A, C, G or T and can be compared."),
+        "ignored_non_acgt_sites": ("Calculated from core.tab calls.", "Positions excluded because at least one call is not A, C, G or T."),
+        "core_tab_matrix_distance": ("core_tab_snp_distances.tsv: matrix cell for this pair.", "Distance independently calculated from core.tab, when the matrix is available."),
+        "core_tab_matrix_matches": ("Comparison of snp_distance and core_tab_matrix_distance.", "yes when both distances agree; no when they differ."),
+        "phylo_aln_distance": ("phylo_snp_distances.tsv: matrix cell for this pair.", "Distance in the phylogenetic alignment, when available."),
+        "phylo_matches_core_tab": ("Comparison of snp_distance and phylo_aln_distance.", "yes when both distances agree; no when they differ."),
+        "clean_core_aln_distance": ("clean_core_snp_distances.tsv: matrix cell for this pair.", "Distance after the clean/Gubbins-associated alignment, when available."),
+        "snps_removed_by_gubbins": ("snp_distance − clean_core_aln_distance.", "Differences no longer contributing to the clean-alignment distance."),
+        "clean_distance_valid": ("Comparison of clean_core_aln_distance and snp_distance.", "yes when the clean distance is not greater than the original distance."),
+        "distance_comparison_warnings": ("Calculated from the three distance-matrix comparisons.", "Semicolon-separated matrix discrepancies or missing-matrix warnings."),
+        "pair_selection_rule": ("Command-line parameter --threshold.", "Strict rule used to retain this pair."),
+        "comparable_core_fraction": ("comparable_core_sites / (comparable_core_sites + ignored_non_acgt_sites).", "Fraction of core.tab positions usable for this pair."),
+        "matrix_availability": ("Presence of the three generated distance-matrix files.", "States whether core.tab, phylo and clean-core comparison matrices were available."),
+        "pair_qc_status": ("distance_comparison_warnings.", "PASS when no pair-level matrix warning exists; REVIEW otherwise."),
+        "pair_review_reasons": ("distance_comparison_warnings.", "Pair-level warnings, or none."),
+        "chrom": ("core.tab: CHR.", "Chromosome identifier."),
+        "pos": ("core.tab: POS.", "Genomic coordinate."),
+        "core_ref": ("core.tab: REF.", "Reference base in core.tab."),
+        "sample_1_call": ("core.tab: sample_1 column at this position.", "Base called for sample_1."),
+        "sample_2_call": ("core.tab: sample_2 column at this position.", "Base called for sample_2."),
+        "pair_local_snp_count": ("Other differential core.tab sites for this pair within ±--cluster-window bp.", "Number of pair-specific SNPs in the local window, including this SNP."),
+        "pair_clustered_snp": ("pair_local_snp_count compared with --cluster-min-snps.", "yes when this SNP belongs to a local SNP cluster."),
+        "removed_by_gubbins": ("gubbins.recombination_predictions.gff coordinates.", "yes when the SNP lies in a predicted recombinant interval; only calculated automatically for a single-contig core.tab."),
+        "qc_warnings": ("QC checks on this row's VCF/BAM evidence and context.", "Semicolon-separated flags; they request review and do not remove the row."),
+        "qc_status": ("qc_warnings.", "PASS when no QC flags were raised; REVIEW otherwise."),
+        "review_reasons": ("qc_warnings.", "QC flags for this SNP, or none."),
+    }
+    if column in definitions:
+        return definitions[column]
+    for number in (1, 2):
+        prefix = f"sample_{number}_"
+        if not column.startswith(prefix):
+            continue
+        suffix = column[len(prefix):]
+        sample_label = f"sample_{number}"
+        evidence = {
+            "evidence_status": ("VCF/BAM lookup result.", "How evidence was obtained: variant_record, reference_call_mpileup, or a missing-evidence status."),
+            "evidence_availability": ("evidence_status.", "available when VCF or BAM evidence was obtained; missing otherwise."),
+            "vcf_record_pos": ("snps.vcf: POS.", "Position of the supporting VCF record; blank for BAM-derived reference evidence."),
+            "vcf_ref": ("snps.vcf: REF; for BAM reference evidence, core_ref.", "Reference allele of the supporting record."),
+            "vcf_alt": ("snps.vcf: ALT; for BAM reference evidence, the other sample's call.", "Alternate allele associated with the comparison."),
+            "qual": ("snps.vcf: QUAL.", "Variant quality reported by the caller."),
+            "filter": ("snps.vcf: FILTER.", "VCF filter status reported by the caller."),
+            "genotype": ("snps.vcf: FORMAT/GT.", "Genotype recorded for this sample."),
+            "depth": ("snps.vcf: FORMAT/DP, otherwise INFO/DP; BAM reference evidence: mpileup depth.", "Total read depth used for allele fractions."),
+            "ref_count": ("snps.vcf: FORMAT/RO, otherwise INFO/RO; BAM reference evidence: parsed mpileup reference bases.", "Reads supporting the reference allele."),
+            "alt_count": ("snps.vcf: FORMAT/AO, otherwise INFO/AO; BAM reference evidence: parsed mpileup bases matching the other sample's call.", "Reads supporting the alternate allele."),
+            "variant_type": ("snps.vcf: INFO/TYPE; BAM reference evidence: reference_call.", "Variant type reported by the caller or reference-call label."),
+            "ref_forward_count": ("snps.raw.vcf: INFO/SRF; BAM reference evidence: parsed mpileup forward bases.", "Reference-supporting reads on the forward strand."),
+            "ref_reverse_count": ("snps.raw.vcf: INFO/SRR; BAM reference evidence: parsed mpileup reverse bases.", "Reference-supporting reads on the reverse strand."),
+            "alt_forward_count": ("snps.raw.vcf: INFO/SAF; BAM reference evidence: parsed mpileup forward bases.", "Alternate-supporting reads on the forward strand."),
+            "alt_reverse_count": ("snps.raw.vcf: INFO/SAR; BAM reference evidence: parsed mpileup reverse bases.", "Alternate-supporting reads on the reverse strand."),
+            "homopolymer_run": ("snps.raw.vcf: INFO/RUN.", "Homopolymer run length reported by FreeBayes."),
+            "nearest_indel_distance": ("snps.raw.vcf: positions with INFO/TYPE other than snp.", "Distance in bases to the nearest raw indel or complex call."),
+            "ref_fraction": ("ref_count / depth.", "Fraction of depth supporting the reference allele."),
+            "alt_fraction": ("alt_count / depth.", "Fraction of depth supporting the alternate allele."),
+            "called_allele": (f"core.tab: {sample_label} call.", "The base called for this sample at this SNP."),
+            "called_allele_count": ("ref_count when called_allele equals core_ref; otherwise alt_count.", "Read count supporting the called allele."),
+            "called_allele_fraction": ("called_allele_count / depth.", "Fraction of depth supporting the allele called in core.tab."),
+            "called_allele_forward_count": ("Reference or alternate forward count selected according to called_allele.", "Called-allele reads on the forward strand."),
+            "called_allele_reverse_count": ("Reference or alternate reverse count selected according to called_allele.", "Called-allele reads on the reverse strand."),
+            "called_allele_minor_strand_fraction": ("If the core.tab call equals core_ref: min(ref_forward_count, ref_reverse_count) / (ref_forward_count + ref_reverse_count); otherwise the same formula using alt_forward_count and alt_reverse_count.", "Fraction of called-allele reads on the less represented strand; lower values indicate stronger strand imbalance."),
+            "evidence_summary": ("Called-allele count, depth, fraction and strand counts above.", "Human-readable evidence summary for this sample and SNP."),
+        }
+        if suffix in evidence:
+            return evidence[suffix]
+    return ("Column descriptions generated!")
+
+
+def write_data_dictionary(path: Path, pairs_path: Path, variants_path: Path, summary_path: Path | None) -> None:
+    """Create a versioned TSV dictionary from the actual headers written"""
+    tables = [(pairs_path.name, pairs_path), (variants_path.name, variants_path)]
+    if summary_path is not None:
+        tables.append((summary_path.name, summary_path))
+    with path.open("w", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=["table", "column", "source_field_or_calculation", "meaning"], delimiter="\t")
+        writer.writeheader()
+        for table_name, table_path in tables:
+            with table_path.open(newline="") as table:
+                headers = next(csv.reader(table, delimiter="\t"), [])
+            for column in headers:
+                source, description = column_description(column)
+                writer.writerow({"table": table_name, "column": column, "source_field_or_calculation": source, "meaning": description})
+
+
+
+def read_tsv_rows(path: Path) -> tuple[list[str], list[dict[str, str]]]:
+    """Read a result TSV preserving its header order for a summary Excel worksheet"""
+    with path.open(newline="") as handle:
+        reader = csv.DictReader(handle, delimiter="\t")
+        return list(reader.fieldnames or []), list(reader)
+
+
+
+def excel_cell_value(header: str, value: str) -> int | float | str:
+    """
+    Convert quantitative result columns to Excel numbers to avoid issues when opening such file
+    """
+    numeric_columns = {
+        "pos", "snp_distance", "comparable_core_sites", "ignored_non_acgt_sites",
+        "core_tab_matrix_distance", "phylo_aln_distance", "clean_core_aln_distance",
+        "snps_removed_by_gubbins", "comparable_core_fraction", "pair_local_snp_count",
+    }
+    numeric_suffixes = (
+        "_vcf_record_pos", "_qual", "_depth", "_ref_count", "_alt_count",
+        "_ref_forward_count", "_ref_reverse_count", "_alt_forward_count",
+        "_alt_reverse_count", "_homopolymer_run", "_nearest_indel_distance",
+        "_ref_fraction", "_alt_fraction", "_called_allele_count",
+        "_called_allele_fraction", "_called_allele_forward_count",
+        "_called_allele_reverse_count", "_called_allele_minor_strand_fraction",
+    )
+    if value in ("", "not_available") or (header not in numeric_columns and not header.endswith(numeric_suffixes)):
+        return value
+    try:
+        numeric_value = float(value)
+    except ValueError:
+        return value
+    return int(numeric_value) if numeric_value.is_integer() else numeric_value
+
+
+
+def style_table_worksheet(ws, headers: list[str], rows: list[dict[str, str]]) -> None:
+    """Write and format an initial README sheet in the Excel output file, from TSV records"""
+    from openpyxl.styles import Alignment, Font, PatternFill
+    from openpyxl.utils import get_column_letter
+
+    header_fill = PatternFill("solid", fgColor="4472C4")
+    for column, header in enumerate(headers, start=1):
+        cell = ws.cell(1, column, header)
+        cell.font = Font(bold=True, color="FFFFFF")
+        cell.fill = header_fill
+        cell.alignment = Alignment(wrap_text=True, vertical="top")
+    for row_number, row in enumerate(rows, start=2):
+        for column, header in enumerate(headers, start=1):
+            value = excel_cell_value(header, row.get(header, ""))
+            cell = ws.cell(row_number, column, value)
+            if isinstance(value, (int, float)):
+                cell.number_format = "0.0000" if header.endswith("_fraction") else "0"
+            cell.alignment = Alignment(wrap_text=True, vertical="top")
+    if headers:
+        ws.freeze_panes = "A2"
+        ws.auto_filter.ref = f"A1:{get_column_letter(len(headers))}{max(1, len(rows) + 1)}"
+        for column, header in enumerate(headers, start=1):
+            longest = max([len(header)] + [len(str(row.get(header, ""))) for row in rows])
+            ws.column_dimensions[get_column_letter(column)].width = min(max(longest + 2, 12), 45)
+
+
+def write_excel_report(
+    path: Path,
+    pairs_path: Path,
+    variants_path: Path,
+    summary_path: Path | None,
+    dictionary_path: Path | None,
+    args: argparse.Namespace,
+    sample_count: int,
+    core_site_count: int,
+) -> None:
+    """Create an Excel report with a first-sheet README, using the style defined in style_table_worksheet.
+    README explains the role of every sheet, the distance definition, the sources of
+    variant evidence, and the most important interpretation caveats.
+    """
+    try:
+        from openpyxl import Workbook
+        from openpyxl.styles import Alignment, Font, PatternFill
+        from openpyxl.utils import get_column_letter
+    except ImportError as error:
+        raise RuntimeError(
+            "Excel report requested but openpyxl is not installed; please install openpyxl "
+            "or use --no-excel"
+        ) from error
+
+    workbook = Workbook()
+    readme = workbook.active
+    readme.title = "README"
+    title_fill = PatternFill("solid", fgColor="1F4E78")
+    section_fill = PatternFill("solid", fgColor="D9EAF7")
+    readme.merge_cells("A1:C1")
+    readme["A1"] = "Close-pair SNP QC report"
+    readme["A1"].font = Font(bold=True, color="FFFFFF", size=14)
+    readme["A1"].fill = title_fill
+    readme["A1"].alignment = Alignment(vertical="center")
+    readme.append([])
+    readme.append(["Sheet", "What it contains", "How to use it"])
+    for cell in readme[3]:
+        cell.font = Font(bold=True)
+        cell.fill = section_fill
+    sheet_entries = [
+        ("README", "This index of the workbook sheets.", "Start here."),
+        ("Close pairs", "One row per pair of samples retained below the requested SNP threshold.", "Use it to identify close pairs and inspect distance-matrix consistency."),
+        ("SNP variants", "One technical row for each SNP that differs within a retained pair.", "Use it for detailed VCF, BAM and QC evidence."),
+    ]
+    if summary_path is not None:
+        sheet_entries.append(("Variant summary", "A compact version of the SNP-variant table.", "Use it for manual evaluation; consult SNP variants sheet to check all fields."))
+    if dictionary_path is not None:
+        sheet_entries.append(("Column descriptions", "Definition and exact source field or calculation for every output column.", "Check this sheet to find the meaning of each column field."))
+    for entry in sheet_entries:
+        readme.append(entry)
+    for row in readme.iter_rows():
+        for cell in row:
+            cell.alignment = Alignment(wrap_text=True, vertical="top")
+    for column, width in enumerate((28, 58, 65), start=1):
+        readme.column_dimensions[get_column_letter(column)].width = width
+    readme.freeze_panes = "A4"
+
+    sheets = [
+        ("Close pairs", pairs_path),
+        ("SNP variants", variants_path),
+    ]
+    if summary_path is not None:
+        sheets.append(("Variant summary", summary_path))
+    if dictionary_path is not None:
+        sheets.append(("Column descriptions", dictionary_path))
+    for sheet_name, table_path in sheets:
+        worksheet = workbook.create_sheet(sheet_name)
+        headers, rows = read_tsv_rows(table_path)
+        style_table_worksheet(worksheet, headers, rows)
+    workbook.save(path)
+
+
+
+def sha256_file(path: Path) -> str | None:
+    """Return a content hash for a present input file, otherwise ``None``."""
+    if not path.is_file():
+        return None
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def write_metadata(path: Path, args: argparse.Namespace, core_tab: Path, pairs_path: Path, variants_path: Path, summary_path: Path | None, excel_path: Path | None) -> None:
+    """Write provenance sufficient to interpret and reproduce a result table."""
+    metadata = {
+        "script": "evaluate_close_pairs.py",
+        "created_utc": datetime.now(timezone.utc).isoformat(),
+        "python_version": sys.version,
+        "parameters": {
+            key: str(value.resolve()) if isinstance(value, Path) else value
+            for key, value in vars(args).items()
+        },
+        "inputs": {"core_tab": {"path": str(core_tab), "sha256": sha256_file(core_tab)}},
+        "outputs": [str(pairs_path), str(variants_path)] + ([str(summary_path)] if summary_path else []) + ([str(excel_path)] if excel_path else []),
+    }
+    path.write_text(json.dumps(metadata, indent=2) + "\n")
+
+
 def main() -> int:
+    """Run close-pair detection, evidence collection, QC and report generation."""
     args = parse_args()
     if args.threshold <= 0:
         raise ValueError("--threshold must be greater than zero")
@@ -924,6 +1372,33 @@ def main() -> int:
                 row["qc_warnings"] = ";".join(dict.fromkeys(row_warning_types))
                 writer.writerow(row)
 
+    variant_rows = enhance_output_tables(pairs_path, variants_path, args.threshold)
+    summary_path = None
+    if not args.no_summary:
+        summary_path = prefix.with_name(prefix.name + "_variants_summary.tsv")
+        write_variant_summary(summary_path, variant_rows)
+    dictionary_path = None
+    if not args.no_data_dictionary:
+        dictionary_path = prefix.with_name(prefix.name + "_column_descriptions.tsv")
+        write_data_dictionary(dictionary_path, pairs_path, variants_path, summary_path)
+    excel_path = None
+    if not args.no_excel:
+        excel_path = args.excel_output or prefix.with_name(prefix.name + "_report.xlsx")
+        if not excel_path.is_absolute():
+            excel_path = Path.cwd() / excel_path
+        try:
+            write_excel_report(
+                excel_path, pairs_path, variants_path, summary_path, dictionary_path,
+                args, len(samples), len(sites),
+            )
+        except RuntimeError as error:
+            print(f"WARNING: {error}", file=sys.stderr)
+            excel_path = None
+    metadata_path = None
+    if not args.no_metadata:
+        metadata_path = prefix.with_name(prefix.name + "_metadata.json")
+        write_metadata(metadata_path, args, core_tab, pairs_path, variants_path, summary_path, excel_path)
+
     variant_count = sum(len(pair["differences"]) for pair in pairs)
     print(f"Samples: {len(samples)}")
     print(f"Core SNP sites: {len(sites)}")
@@ -931,6 +1406,14 @@ def main() -> int:
     print(f"Pair-specific variant rows: {variant_count}")
     print(f"Wrote: {pairs_path}")
     print(f"Wrote: {variants_path}")
+    if summary_path:
+        print(f"Wrote: {summary_path}")
+    if dictionary_path:
+        print(f"Wrote: {dictionary_path}")
+    if excel_path:
+        print(f"Wrote: {excel_path}")
+    if metadata_path:
+        print(f"Wrote: {metadata_path}")
     if not args.no_qc_warnings:
         for warning_type, message in qc_warnings.values():
             print(f"WARNING [{warning_type}] {message}")

--- a/buisciii/templates/snippy/ANALYSIS/ANALYSIS01_SNIPPY/05-snippy/lablog
+++ b/buisciii/templates/snippy/ANALYSIS/ANALYSIS01_SNIPPY/05-snippy/lablog
@@ -88,15 +88,23 @@ echo "srun --chdir ${scratch_dir} --output logs/SNP_DISTANCE_MATRICES.%j.log --j
 ## Output files:
 ##   core_tab_snp_distances.tsv     distances calculated directly from core.tab
 ##   phylo_snp_distances.tsv        distances calculated from phylo.aln
-##   clean_core_snp_distances.tsv    distances calculated from clean.core.aln
-##   snp_distance_matrices_metadata.json sources, sample counts, and site counts
+##   clean_core_snp_distances.tsv   distances calculated from clean.core.aln
+##   snp_distance_matrices_metadata.json    sources, sample counts, and site counts
 ##   close_pair_snp_qc_pairs.tsv    close pairs and their SNP distances
-##   close_pair_snp_qc_variants.tsv differing positions, read evidence, and a
-##                                    semicolon-separated qc_warnings column
+##   close_pair_snp_qc_variants.tsv differing positions, read evidence, and a semicolon-separated qc_warnings column
+##   close_pair_snp_qc_variants_summary.tsv compact, human-readable SNP review table
+##   close_pair_snp_qc_column_descriptions.tsv  source and definition of every output column
+##   close_pair_snp_qc_report.xlsx  Excel report with README and result sheets
+##   close_pair_snp_qc_metadata.json    run parameters, resolved input paths and core.tab SHA-256 provenance
+##
+## The summary, column-description, metadata and Excel files are written by
+## default. Use --no-summary, --no-column-descriptions,
+## --no-metadata or --no-excel to omit them; --excel-output sets a custom name.
 ##
 ## Possible qc_warnings values include low_depth, low_called_fraction,
 ## strand_bias, near_indel_or_complex, homopolymer_context, local_snp_cluster,
 ## missing_depth, missing_called_fraction, and missing_evidence.
+##
 ## --no-qc-warnings suppresses the long per-position stdout list; warning totals
 ## are still printed, and all row-level warnings remain in the variants TSV.
 ## In the variants TSV, filter removed_by_gubbins=yes or qc_warnings containing

--- a/buisciii/templates/snippy/ANALYSIS/ANALYSIS01_SNIPPY/05-snippy/lablog
+++ b/buisciii/templates/snippy/ANALYSIS/ANALYSIS01_SNIPPY/05-snippy/lablog
@@ -93,13 +93,13 @@ echo "srun --chdir ${scratch_dir} --output logs/SNP_DISTANCE_MATRICES.%j.log --j
 ##   close_pair_snp_qc_pairs.tsv    close pairs and their SNP distances
 ##   close_pair_snp_qc_variants.tsv differing positions, read evidence, and a semicolon-separated qc_warnings column
 ##   close_pair_snp_qc_variants_summary.tsv compact, human-readable SNP review table
-##   close_pair_snp_qc_column_descriptions.tsv  source and definition of every output column
-##   close_pair_snp_qc_report.xlsx  Excel report with README and result sheets
+##   close_pair_snp_qc_report.xlsx  Excel report with README, result sheets,
+##                                  and column descriptions
 ##   close_pair_snp_qc_metadata.json    run parameters, resolved input paths and core.tab SHA-256 provenance
 ##
-## The summary, column-description, metadata and Excel files are written by
-## default. Use --no-summary, --no-column-descriptions,
-## --no-metadata or --no-excel to omit them; --excel-output sets a custom name.
+## The summary, metadata and Excel files are written by default. Use
+## --no-summary, --no-metadata or --no-excel to omit them; --excel-output sets
+## a custom name.
 ##
 ## Possible qc_warnings values include low_depth, low_called_fraction,
 ## strand_bias, near_indel_or_complex, homopolymer_context, local_snp_cluster,


### PR DESCRIPTION
<!--
# bu-isciii tools pull request

Based on nf-core/viralrecon pull request template

Fill in the appropriate checklist below and delete whatever is not relevant.

PRs should be made against the develop of hotfix branch, unless you're preparing a software release.
-->

## PR checklist

- [X] This comment contains a description of changes (with reason).
- [X] Make sure your code lints (`black and flake8`).
- If a new tamplate was added make sure:
    - [ ] Template's schema is added in `templates/services.json`.
    - [ ] Template's pipeline's documentation in `assets/reports/md/template.md` is added.
    - [ ] Results Documentation in `assets/reports/results/template.md` is updated.
- [X] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
- [ ] If you know a new user was added to the SFTP, make sure you added it to `templates/sftp_user.json`

## PR description

The `evaluate_close_pairs.py` was added a few enhancements:
- First of all, an Excel file is generated including the results from all the separate TSV output files, so that they can be consulted directly from the same Excel file. The TSV files are still generated separately in case they might be useful for other purposes. This Excel file includes an initial README sheet explaining the content of each sheet, and then four sheets are shown: close pairs, SNP variants, variant summary and column descriptions.
- As indicated above, a new TSV file is created, which is also added into the Excel file: variant summary, containing the most significant columns of the SNP-variants file. Even though this is not created as a separate file, there will be a final sheet in the Excel file called "Column descriptions", which describes in detail the source and the explanation of each one of the columns of all the TSV files, so that the user can interpret correctly their content.
- A metadata JSON file is created as well, indicating the selected values for each one of the parameters as well as the input and output filepaths.

- Regarding the already existing close pairs file, the following columns have been added:
  - Comparable_core_fraction: indicates the fraction of sites from core.tab that could be used, depending on the number of non-ACGT sites.
  - Matrix_availability: indicates if all expected input files could be found.
- Regarding the already existing SNP variants file, the following columns have been added:
  - Called_allele_minor_strand_fraction: Fraction of called-allele reads on the less represented strand; lower values indicate stronger strand imbalance.
  - Evidence_summary: evidence summary for each sample and SNP.

- Additionally, an important enhancement has been implemented when running `samtools mpileup`. There is a discrepancy between the results reported by this tool and `samtools depth`, since the first skips anomalous read pairs, performs base alignment quality (BAQ) computation and does overlap detection and removal by default, which leads to different results being obtained when running this tool. Since snippy uses `samtools depth` to mask low-depth positions, `samtools mpileup` is run in `evaluate_close_pairs.py` with the -A, -B and -x options in order to obtain the same results as the ones that would be obtained if running `samtools depth`, so that low-depth warnings are correctly reported in the Excel and TSV files.