### PR TITLE
Fix lablog_assembly FASTQ  matching with shared sample prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,33 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.3.5]_dev - XXXX-XX-XX : https://github.com/BU-ISCIII/buisciii-tools/releases/tag/2.3.5
-
-### Credits
-
-- [Pau Pascual](https://github.com/PauPascualMas)
-
-
-### Template fixes and updates
-- Fix lablog_assembly FASTQ matching with shared sample prefix (https://github.com/BU-ISCIII/buisciii-tools/pull/726)
-
-
-### Modules
-
-#### Implementation
-
-#### Added enhancements
-
-#### Fixes
-
-#### Changed
-
-#### Removed
-
-### Requirements
-
-
-## [2.3.4] - 2026-07-02 : https://github.com/BU-ISCIII/buisciii-tools/releases/tag/2.3.4
+## [2.3.4dev] - 2026-XX-XX : https://github.com/BU-ISCIII/buisciii-tools/releases/tag/2.3.4dev
 
 ### Credits
 
@@ -53,6 +27,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Added reusable Snippy SNP-distance matrices and close-pair variant QC tooling [#718](https://github.com/BU-ISCIII/buisciii-tools/pull/718)
 - Fix IRMA stats generation when 3-match is absent [#719](https://github.com/BU-ISCIII/buisciii-tools/pull/719)
 - Modified bind in BLAST lablog to alow access to refgenie data [#722](https://github.com/BU-ISCIII/buisciii-tools/pull/722)
+- Enhanced the SNP QC script from snippy's template [#724](https://github.com/BU-ISCIII/buisciii-tools/pull/724).
+- Fix lablog_assembly FASTQ matching with shared sample prefix (https://github.com/BU-ISCIII/buisciii-tools/pull/726).
 
 ### Modules
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,31 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.5]_dev - XXXX-XX-XX : https://github.com/BU-ISCIII/buisciii-tools/releases/tag/2.3.5
+
+### Credits
+
+- [Pau Pascual](https://github.com/PauPascualMas)
+
+
+### Template fixes and updates
+- Fix lablog_assembly FASTQ matching with shared sample prefix (https://github.com/BU-ISCIII/buisciii-tools/pull/726)
+
+
+### Modules
+
+#### Implementation
+
+#### Added enhancements
+
+#### Fixes
+
+#### Changed
+
+#### Removed
+
+### Requirements
+
 
 ## [2.3.4] - 2026-07-02 : https://github.com/BU-ISCIII/buisciii-tools/releases/tag/2.3.4
 

--- a/buisciii/templates/assembly/ANALYSIS/lablog_assembly
+++ b/buisciii/templates/assembly/ANALYSIS/lablog_assembly
@@ -1,20 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+shopt -s nullglob
+
 mkdir -p 00-reads
 cd 00-reads
 
-# Loop through each file in the directory
-while IFS= read -r sample; do
-    # Extract the file name with&without extension
-    filename_noext=$(basename -s .fastq.gz ../../RAW/${sample}*)
+while IFS= read -r sample || [[ -n "$sample" ]]; do
+    # Remove Windows carriage returns and skip empty lines
+    sample=${sample//$'\r'/}
+    [[ -z "$sample" ]] && continue
 
-    ### Check if reads are single o paired end
-    for fileitem in $filename_noext; do
-        if [[ "$fileitem" =~ _R[12] ]]; then
-            ln -s -f ../../RAW/${sample}*_R1*.fastq.gz ${sample}_R1.fastq.gz
-            ln -s -f ../../RAW/${sample}*_R2*.fastq.gz ${sample}_R2.fastq.gz
-        elif [[ ! "$fileitem" =~ _R[12] ]]; then
-            ln -s -f ../../RAW/${sample}.fastq.gz ${sample}.fastq.gz
-        fi
-    done
+    # Require "_S" after the exact sample ID to avoid prefix matches
+    r1_files=(../../RAW/"${sample}"_S*_R1_*.fastq.gz)
+    r2_files=(../../RAW/"${sample}"_S*_R2_*.fastq.gz)
+    single_files=(../../RAW/"${sample}"_S*.fastq.gz)
+
+    if (( ${#r1_files[@]} == 1 && ${#r2_files[@]} == 1 )); then
+        ln -sfn "${r1_files[0]}" "${sample}_R1.fastq.gz"
+        ln -sfn "${r2_files[0]}" "${sample}_R2.fastq.gz"
+
+        echo "PAIRED: $sample"
+
+    elif (( ${#r1_files[@]} > 1 || ${#r2_files[@]} > 1 )); then
+        echo "ERROR: multiple FASTQ pairs found for $sample" >&2
+        printf '  %s\n' "${r1_files[@]}" "${r2_files[@]}" >&2
+
+    elif (( ${#single_files[@]} == 1 )); then
+        ln -sfn "${single_files[0]}" "${sample}.fastq.gz"
+
+        echo "SINGLE: $sample"
+
+    elif (( ${#single_files[@]} > 1 )); then
+        echo "ERROR: multiple single-end FASTQs found for $sample" >&2
+        printf '  %s\n' "${single_files[@]}" >&2
+
+    else
+        echo "MISSING: $sample" >&2
+    fi
 done < ../samples_id.txt
 
 cd -


### PR DESCRIPTION
<!--
# bu-isciii tools pull request

Based on nf-core/viralrecon pull request template

Fill in the appropriate checklist below and delete whatever is not relevant.

PRs should be made against the develop of hotfix branch, unless you're preparing a software release.
-->
## PR Description

This PR fixes incorrect FASTQ matching in the assembly lablog when sample IDs share the same prefix.

The previous implementation used:

```bash
../../RAW/${sample}*
```

This could match a different sample whose identifier started with the same text.

For example, requesting:

```text
S20262343
```

could incorrectly match:

```text
S20262343R_S288_R1_001.fastq.gz
S20262343R_S288_R2_001.fastq.gz
```

and create misleading symlinks named:

```text
S20262343_R1.fastq.gz
S20262343_R2.fastq.gz
```

## Changes

* Require `_S` immediately after the sample ID when matching Illumina FASTQ filenames.
* Use Bash arrays with `nullglob` to safely detect zero, one, or multiple matches.
* Validate that exactly one R1 and one R2 file are found for paired-end samples.
* Continue supporting single-end FASTQ files.
* Report missing samples explicitly.
* Report ambiguous cases where multiple files match.
* Remove Windows carriage returns from `samples_id.txt`.
* Skip empty lines.
* Use `set -euo pipefail` for safer script execution.
* Use `ln -sfn` when creating or replacing symlinks.

## New matching pattern

Paired-end reads are now matched using:

```bash
../../RAW/"${sample}"_S*_R1_*.fastq.gz
../../RAW/"${sample}"_S*_R2_*.fastq.gz
```

This ensures that a sample such as `S20262343` does not match samples such as `S20262343R` or `S20262343-2`.

## Error handling

The script now distinguishes between:

```text
PAIRED: <sample>
SINGLE: <sample>
MISSING: <sample>
ERROR: multiple FASTQ pairs found for <sample>
ERROR: multiple single-end FASTQs found for <sample>
```

No symlink is created when the sample is missing or when the match is ambiguous.

## Testing

The fix was tested with sample IDs that have similarly prefixed alternatives, including:

```text
S20262138 / S20262138R
S20262327 / S20262327R
S20262328 / S20262328R
S20262342 / S20262342-2
S20262343 / S20262343R
S20262344 / S20262344-2
S20262345 / S20262345-2
S20262346 / S20262346-2
```

The unsuffixed sample IDs are now correctly reported as missing instead of linking reads from the suffixed samples.

## Expected result

Only FASTQ files belonging to the exact sample ID are linked into `00-reads`, preventing samples from being processed under the wrong identifier.

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] Make sure your code lints (`black and flake8`).
- If a new tamplate was added make sure:
    - [ ] Template's schema is added in `templates/services.json`.
    - [ ] Template's pipeline's documentation in `assets/reports/md/template.md` is added.
    - [ ] Results Documentation in `assets/reports/results/template.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
- [ ] If you know a new user was added to the SFTP, make sure you added it to `templates/sftp_user.json`
